### PR TITLE
Measure the install, not just the copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,15 @@ AUTH_FACEBOOK_SECRET=""
 # ─── Showcase moderation ────────────────────────────────────────────────────
 # Comma-separated emails allowed to open /docs/showcase/admin and approve/reject.
 ADMIN_EMAILS="admin@simplifyingai.com"
+
+# ─── Analytics (PostHog) ────────────────────────────────────────────────────
+# Project API key — "Project settings → Project API key". Public by design; it
+# is in the client bundle. Without it the site runs with analytics disabled
+# rather than broken, so a fork needs nothing here.
+NEXT_PUBLIC_POSTHOG_KEY=""
+# Dashboard host, which also picks the region. US (default) or EU:
+#   https://us.posthog.com  |  https://eu.posthog.com
+# next.config.ts derives the ingest + asset hosts from this, so region is one
+# value, not three. Ingestion is proxied through this origin at /ingest — see
+# app/posthog-provider.tsx for why that matters for a developer audience.
+NEXT_PUBLIC_POSTHOG_HOST="https://us.posthog.com"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,23 @@ A single flat Next.js app (no monorepo):
 - `scripts/` — Remotion bundling and demo-rendering scripts
 - `config/`, `lib/`, `hooks/` — site configuration, analytics, utilities
 
+## Analytics
+
+PostHog, and **only** PostHog — do not add a second tracker. Two places:
+
+- `lib/analytics.ts` — the typed client event map + `useTrackEvent()`. Every
+  browser-side event is declared there with the question it answers. Read the
+  header comment before adding one; if you can't name the question, don't.
+- `lib/analytics-server.ts` + `middleware.ts` — the events that happen outside a
+  browser. `/r/<component>.json` is the actual install (what `shadcn add`
+  fetches) and is the conversion metric this whole site feeds; `/llms.txt`
+  measures the AI-agent channel; `/api/search` records zero-result queries,
+  which are component requests in disguise.
+
+Autocapture, pageviews, pageleave, web vitals, exceptions and session replay are
+all SDK config in `app/posthog-provider.tsx` — don't hand-roll any of them.
+Events are not sent from `pnpm dev`; verify with `pnpm build && pnpm start`.
+
 ## Two component tiers
 
 - **Primitives** — individual animations, transitions, backgrounds

--- a/app/(home)/components/github-button-link.tsx
+++ b/app/(home)/components/github-button-link.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { GITHUB_URL } from "@/config/site";
+import { useTrackEvent } from "@/lib/analytics";
+
+/**
+ * The clickable half of `GithubButton`.
+ *
+ * Split off only because the star count is fetched on the server and an
+ * `onClick` cannot cross that boundary. Everything visual stays in the parent;
+ * this file exists so the header CTA reports `cta_clicked` like every other CTA
+ * on the site, instead of relying on autocapture to notice a `data-` attribute.
+ */
+export function GithubButtonLink({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const trackEvent = useTrackEvent();
+
+  return (
+    <Link
+      href={GITHUB_URL}
+      target="_blank"
+      rel="noreferrer"
+      className={className}
+      onClick={() =>
+        trackEvent("cta_clicked", {
+          cta: "github_header",
+          destination: GITHUB_URL,
+        })
+      }
+    >
+      {children}
+    </Link>
+  );
+}

--- a/app/(home)/components/github-button.tsx
+++ b/app/(home)/components/github-button.tsx
@@ -1,20 +1,11 @@
 import { Star } from "lucide-react";
-import Link from "next/link";
-import { GITHUB_URL } from "@/config/site";
 import { formatStars, getGitHubStars } from "@/lib/github";
+import { GithubButtonLink } from "./github-button-link";
 
 export async function GithubButton() {
   const stars = await getGitHubStars();
   return (
-    <Link
-      href={GITHUB_URL}
-      target="_blank"
-      rel="noreferrer"
-      data-track="cta_clicked"
-      data-cta="github_header"
-      data-destination={GITHUB_URL}
-      className="inline-flex h-9 items-center gap-2 rounded-4xl border border-border px-3 text-sm font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-    >
+    <GithubButtonLink className="inline-flex h-9 items-center gap-2 rounded-4xl border border-border px-3 text-sm font-medium text-muted-foreground transition-colors duration-150 ease-out hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
       <GitHubIcon className="size-4" />
       <span className="hidden sm:inline">Star</span>
       {/* `> 0`, not `!== null`: the count used to be dead code, because the repo
@@ -27,7 +18,7 @@ export async function GithubButton() {
           {formatStars(stars)}
         </span>
       )}
-    </Link>
+    </GithubButtonLink>
   );
 }
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,4 +1,82 @@
 import { createFromSource } from "fumadocs-core/search/server";
+import { after } from "next/server";
+import {
+  anonymousId,
+  captureServer,
+  distinctIdFromCookie,
+} from "@/lib/analytics-server";
 import { source } from "@/source";
 
-export const { GET } = createFromSource(source);
+/**
+ * Docs search, wrapped so that every query is recorded with its result count.
+ *
+ * ## Why here and not in the search dialog
+ *
+ * The dialog is fumadocs'. Instrumenting it would mean forking a component we
+ * otherwise get for free, and re-forking it on every fumadocs upgrade. This
+ * route is the one thing every search — from the dialog, from `⌘K`, from a
+ * direct hit — necessarily passes through, and wrapping it is nine lines.
+ *
+ * ## Why it is worth recording at all
+ *
+ * A query that returns **zero results is a component request written by a user
+ * who did not know they were filing one.** Someone typing "confetti", "ken
+ * burns", "waveform" into a registry that has none of them is the single
+ * highest-signal input to what gets built next, and it is invisible in every
+ * other event on the site — they search, find nothing, and leave without
+ * clicking anything we could have measured.
+ */
+const { GET: search } = createFromSource(source);
+
+export async function GET(request: Request) {
+  const response = await search(request);
+
+  const query = new URL(request.url).searchParams.get("query")?.trim();
+  // Fumadocs fires a request per keystroke. One- and two-character queries are
+  // that debounce leaking through, not intent, and logging them would bury the
+  // real ones.
+  if (query && query.length >= 3) {
+    // `clone()`: the body can only be read once, and the caller needs it.
+    const results = await response
+      .clone()
+      .json()
+      .then((r: unknown) => (Array.isArray(r) ? r.length : 0))
+      .catch(() => 0);
+
+    after(async () => {
+      const ua = request.headers.get("user-agent");
+      const distinctId =
+        distinctIdFromCookie(cookieJar(request)) ??
+        (await anonymousId(
+          request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+            "unknown",
+          ua ?? "none",
+        ));
+      await captureServer("docs_searched", distinctId, {
+        query: query.toLowerCase(),
+        results,
+        // The property to build the "what are we missing" insight on.
+        zero_results: results === 0,
+      });
+    });
+  }
+
+  return response;
+}
+
+/** `distinctIdFromCookie` wants a `cookies.get(name)` shape; Request has a header. */
+function cookieJar(request: Request) {
+  const header = request.headers.get("cookie") ?? "";
+  return {
+    get(name: string) {
+      for (const part of header.split(";")) {
+        const eq = part.indexOf("=");
+        if (eq === -1) continue;
+        if (part.slice(0, eq).trim() === name) {
+          return { value: part.slice(eq + 1).trim() };
+        }
+      }
+      return undefined;
+    },
+  };
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,8 @@ import { Caveat, Geist, Geist_Mono, Outfit } from "next/font/google";
 import localFont from "next/font/local";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
-import { OpenPanelComponent } from "@openpanel/nextjs";
 import { cn } from "@/lib/utils";
+import { PostHogProvider } from "./posthog-provider";
 import { SnapCnThemeBridge } from "./snap-cn-theme-bridge";
 import { ThemeShortcut } from "./theme-shortcut";
 
@@ -134,24 +134,19 @@ export default function RootLayout({
       )}
     >
       <body className="min-h-full flex flex-col">
-        <NuqsAdapter>
-          <RootProvider
-            theme={{
-              defaultTheme: "system",
-              enableSystem: true,
-            }}
-          >
-            <ThemeShortcut />
-            <SnapCnThemeBridge>{children}</SnapCnThemeBridge>
-          </RootProvider>
-        </NuqsAdapter>
-        <OpenPanelComponent
-          clientId={process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID as string}
-          apiUrl={process.env.NEXT_PUBLIC_OPENPANEL_API_URL}
-          trackScreenViews
-          trackAttributes
-          trackOutgoingLinks
-        />
+        <PostHogProvider>
+          <NuqsAdapter>
+            <RootProvider
+              theme={{
+                defaultTheme: "system",
+                enableSystem: true,
+              }}
+            >
+              <ThemeShortcut />
+              <SnapCnThemeBridge>{children}</SnapCnThemeBridge>
+            </RootProvider>
+          </NuqsAdapter>
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/app/posthog-provider.tsx
+++ b/app/posthog-provider.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { useEffect } from "react";
+
+/**
+ * Boots posthog-js.
+ *
+ * ## Why the ingest path is `/ingest` and not PostHog's own host
+ *
+ * This site's audience is frontend developers. Ad-blocker use in that group is
+ * not the general population's — a direct `us.i.posthog.com` endpoint is on
+ * every blocklist there is, and the traffic we would lose is exactly the
+ * traffic we care most about measuring. `/ingest` is a same-origin rewrite (see
+ * `next.config.ts`) so there is nothing third-party for a blocker to match.
+ *
+ * ## Why no manual pageview effect
+ *
+ * The usual App Router recipe pairs this provider with a `usePathname` +
+ * `useSearchParams` effect that fires `$pageview` on every navigation. That
+ * recipe predates `capture_pageview: "history_change"`, which makes the SDK
+ * itself watch the History API and covers soft navigation without a component,
+ * a Suspense boundary, or the double-fire that recipe is famous for.
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    // No key (a fork, a local checkout, a preview build) → no tracker, and every
+    // `trackEvent` call downstream turns into a no-op rather than a crash.
+    if (!key) return;
+
+    posthog.init(key, {
+      api_host: "/ingest",
+      // Where the SDK sends people for the toolbar/debug links. The proxy above
+      // only covers ingestion, so this has to be the real dashboard host.
+      ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.posthog.com",
+
+      // App Router soft navigations, without a manual effect. See above.
+      capture_pageview: "history_change",
+      // Gives every pageview a duration, which is the only way to tell a docs
+      // page that was read from one that was bounced off.
+      capture_pageleave: true,
+
+      // Anonymous visitors are counted as events but do not each mint a person
+      // profile. On a marketing site that is the difference between a person
+      // count that reflects our users and one that reflects our crawlers.
+      // `identifyUser()` promotes someone the moment they sign in.
+      person_profiles: "identified_only",
+
+      // Unhandled errors and rejections, reported with the session that caused
+      // them. Cheapest error monitoring that exists: one flag.
+      capture_exceptions: true,
+
+      // Session replay. For a product whose entire pitch is "look at how this
+      // moves", watching one person fail to find the Customize panel is worth
+      // more than a month of aggregate counts. Inputs are masked by default.
+      disable_session_recording: false,
+
+      // `pnpm dev` would otherwise post local clicking-around into the same
+      // project the conversion numbers are read from. Events are still built and
+      // logged (`debug()`), just not sent — so you can verify wiring from the
+      // console. To verify end-to-end, run `pnpm build && pnpm start`: NODE_ENV
+      // is "production" there and events go out for real.
+      loaded: (ph) => {
+        if (process.env.NODE_ENV === "development") ph.debug();
+      },
+      before_send: (event) =>
+        process.env.NODE_ENV === "development" ? null : event,
+    });
+  }, []);
+
+  return <PHProvider client={posthog}>{children}</PHProvider>;
+}

--- a/components/docs/component-preview.tsx
+++ b/components/docs/component-preview.tsx
@@ -109,7 +109,16 @@ function Preview({
 
   return (
     <div className="not-prose mb-6 flex w-full flex-col gap-4">
-      <Tabs defaultValue="preview" className="gap-3">
+      <Tabs
+        defaultValue="preview"
+        className="gap-3"
+        // Reading the source before installing is the shadcn-user tell that
+        // separates browsing from evaluating.
+        onValueChange={(value) => {
+          if (value === "code")
+            trackEvent("component_code_viewed", { component: name });
+        }}
+      >
         <TabsList>
           <TabsTrigger value="preview">Preview</TabsTrigger>
           <TabsTrigger value="code">Code</TabsTrigger>

--- a/components/docs/gallery/gallery-explorer.tsx
+++ b/components/docs/gallery/gallery-explorer.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTrackEvent } from "@/lib/analytics";
 import {
   type CategoryId,
   GALLERY_CATEGORIES,
@@ -71,6 +72,20 @@ export function GalleryExplorer({
     parseAsString.withOptions({ history: "push", shallow: true }),
   );
 
+  const trackEvent = useTrackEvent();
+  // Which shelf people shop. A category nobody ever filters to is either badly
+  // named or badly stocked, and this is the only way to tell which.
+  const setFilter = useCallback(
+    (next: { category?: CategoryId | null; sort?: SortMode }) => {
+      void setState(next);
+      trackEvent("gallery_filtered", {
+        category: next.category !== undefined ? next.category : category,
+        sort: next.sort ?? sort,
+      });
+    },
+    [setState, trackEvent, category, sort],
+  );
+
   // Legacy deep links used a `#<category>` hash (the old scroll-anchor pills).
   // Convert those into the equivalent filter on mount so shared/bookmarked URLs
   // keep working, then strip the hash.
@@ -122,7 +137,7 @@ export function GalleryExplorer({
             <button
               type="button"
               aria-pressed={category === null}
-              onClick={() => void setState({ category: null })}
+              onClick={() => setFilter({ category: null })}
               className={pillClassName(category === null)}
             >
               All
@@ -132,7 +147,7 @@ export function GalleryExplorer({
                 key={c.id}
                 type="button"
                 aria-pressed={category === c.id}
-                onClick={() => void setState({ category: c.id })}
+                onClick={() => setFilter({ category: c.id })}
                 className={pillClassName(category === c.id)}
               >
                 {c.label}
@@ -149,7 +164,7 @@ export function GalleryExplorer({
               <DropdownMenuRadioGroup
                 value={sort}
                 onValueChange={(value) =>
-                  void setState({ sort: value as SortMode })
+                  setFilter({ sort: value as SortMode })
                 }
               >
                 {SORT_ORDER.map((mode) => (

--- a/components/showcase/showcase-header.tsx
+++ b/components/showcase/showcase-header.tsx
@@ -2,7 +2,7 @@
 
 import { LogOut } from "lucide-react";
 import { signOut } from "next-auth/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +13,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Toaster } from "@/components/ui/sonner";
+import { identifyUser, resetUser, useTrackEvent } from "@/lib/analytics";
 import type { AuthProviderId } from "@/lib/auth-providers";
 import { SignInButtons } from "./sign-in-buttons";
 import { SubmitForm } from "./submit-form";
@@ -40,6 +41,21 @@ export function ShowcaseHeader({
 }) {
   const [open, setOpen] = useState(false);
   const signedIn = Boolean(user?.id);
+  const trackEvent = useTrackEvent();
+
+  // This is the only client component on the site that is handed a session, so
+  // it is where an anonymous PostHog person gets promoted to a known one — the
+  // stitch that turns "browsed the docs" and "submitted a video" from two
+  // strangers into one funnel. `identifyUser` is idempotent and returns true
+  // only on the transition, so the effect can run on every visit.
+  useEffect(() => {
+    if (!user?.id) return;
+    const promoted = identifyUser(user.id, {
+      email: user.email ?? undefined,
+      name: user.name ?? undefined,
+    });
+    if (promoted) trackEvent("signed_in");
+  }, [user?.id, user?.email, user?.name, trackEvent]);
 
   return (
     <div className="pt-4">
@@ -71,7 +87,12 @@ export function ShowcaseHeader({
                 variant="ghost"
                 size="icon-sm"
                 aria-label="Sign out"
-                onClick={() => signOut()}
+                onClick={() => {
+                  // Before the redirect: a shared machine must not merge the
+                  // next person's browsing into this account.
+                  resetUser();
+                  signOut();
+                }}
               >
                 <LogOut className="size-4" />
               </Button>

--- a/components/showcase/submit-form.tsx
+++ b/components/showcase/submit-form.tsx
@@ -6,10 +6,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { useTrackEvent } from "@/lib/analytics";
 
 /** Post a new showcase submission. Lands as `pending` for admin review. */
 export function SubmitForm({ onDone }: { onDone?: () => void }) {
   const [submitting, setSubmitting] = useState(false);
+  const trackEvent = useTrackEvent();
   const [title, setTitle] = useState("");
   const [postUrl, setPostUrl] = useState("");
   const [description, setDescription] = useState("");
@@ -28,6 +30,7 @@ export function SubmitForm({ onDone }: { onDone?: () => void }) {
         toast.error(data.error ?? "Couldn't submit — please try again.");
         return;
       }
+      trackEvent("showcase_submitted");
       toast.success("Submitted! We'll review it shortly.");
       setTitle("");
       setPostUrl("");

--- a/components/video-editor/use-editor-export.ts
+++ b/components/video-editor/use-editor-export.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useTrackEvent } from "@/lib/analytics";
 import type { Clip } from "@/lib/video-editor/types";
 
 /**
@@ -24,6 +25,7 @@ export function useEditorExport() {
   const [progress, setProgress] = useState(0);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelledRef = useRef(false);
+  const trackEvent = useTrackEvent();
 
   const stop = useCallback(() => {
     if (pollRef.current) {
@@ -43,6 +45,12 @@ export function useEditorExport() {
       cancelledRef.current = false;
       setExporting(true);
       setProgress(0);
+
+      // Click → downloaded file, measured here rather than on the server,
+      // because the queue wait and the poll interval are part of what the user
+      // actually sits through.
+      const startedAt = Date.now();
+      trackEvent("editor_export_started", { clip_count: clips.length });
 
       try {
         const res = await fetch("/api/render", {
@@ -64,6 +72,10 @@ export function useEditorExport() {
               setProgress(job.progress ?? 0);
               if (job.status === "done" && job.downloadUrl) {
                 triggerDownload(job.downloadUrl);
+                trackEvent("editor_export_succeeded", {
+                  clip_count: clips.length,
+                  duration_ms: Date.now() - startedAt,
+                });
                 return resolve();
               }
               if (job.status === "error") {
@@ -79,6 +91,12 @@ export function useEditorExport() {
       } catch (err) {
         if (!cancelledRef.current) {
           console.error("[video-editor] export failed:", err);
+          // A failed export is a bug report we would otherwise never get — the
+          // user reads the toast and closes the tab.
+          trackEvent("editor_export_failed", {
+            clip_count: clips.length,
+            reason: err instanceof Error ? err.message : String(err),
+          });
           toast.error("Export failed", {
             description: err instanceof Error ? err.message : String(err),
           });
@@ -88,7 +106,7 @@ export function useEditorExport() {
         setExporting(false);
       }
     },
-    [stop],
+    [stop, trackEvent],
   );
 
   return { exporting, progress, download };

--- a/components/video-editor/video-editor.tsx
+++ b/components/video-editor/video-editor.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Download, Loader2 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
+import { useTrackEvent } from "@/lib/analytics";
 import { getDefaults } from "@/lib/customizer-config";
 import {
   type Clip,
@@ -28,22 +29,39 @@ export function VideoEditor() {
   const [clips, setClips] = useState<Clip[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { exporting, progress, download } = useEditorExport();
+  const trackEvent = useTrackEvent();
 
-  const addClip = useCallback((slug: string) => {
-    const entry = registry[slug];
-    if (!entry) return;
-    setClips((prev) => {
-      if (prev.length >= MAX_CLIPS) return prev;
+  // Opened vs. exported is the editor's only funnel — how many people reach it
+  // and then build nothing tells us whether the empty state is the problem.
+  useEffect(() => {
+    trackEvent("editor_opened");
+  }, [trackEvent]);
+
+  // The guard reads `clips` from the closure rather than the updater's `prev`,
+  // because the tracking call has to live OUTSIDE the state updater: React
+  // double-invokes updaters under StrictMode, and a side effect in there fires
+  // twice. `addClip` is only ever called from a click, so the closure is current.
+  const addClip = useCallback(
+    (slug: string) => {
+      const entry = registry[slug];
+      if (!entry || clips.length >= MAX_CLIPS) return;
       const clip: Clip = {
         id: nextClipId(),
         slug,
         props: getDefaults(entry.config.controls),
         durationInFrames: entry.config.durationInFrames,
       };
+      setClips((prev) => [...prev, clip]);
       setSelectedId(clip.id);
-      return [...prev, clip];
-    });
-  }, []);
+      // Which components people reach for when composing a real video — a
+      // different ranking from which docs pages get read.
+      trackEvent("editor_clip_added", {
+        component: slug,
+        clip_count: clips.length + 1,
+      });
+    },
+    [clips.length, trackEvent],
+  );
 
   const updateProp = useCallback(
     (key: string, value: unknown) => {

--- a/lib/__tests__/analytics-server.test.ts
+++ b/lib/__tests__/analytics-server.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { classifyClient } from "../analytics-server";
+
+/**
+ * `classifyClient` is what makes `registry_component_fetched` mean anything: it
+ * separates a real install from a crawler and an agent. Get it wrong and the
+ * headline number on the dashboard is wrong in a way nobody notices, because it
+ * still looks like a plausible install count.
+ *
+ * The ordering cases below are the ones that actually bite — agent user-agents
+ * that contain "bot", and agents that ship a full browser UA string.
+ */
+describe("classifyClient", () => {
+  it("counts a bare shadcn/Node fetch as a CLI install", () => {
+    expect(classifyClient(null)).toBe("cli");
+    expect(classifyClient("node")).toBe("cli");
+    expect(classifyClient("undici")).toBe("cli");
+    expect(classifyClient("shadcn/4.11.0")).toBe("cli");
+    expect(classifyClient("curl/8.4.0")).toBe("cli");
+  });
+
+  it("puts AI agents ahead of the bot and browser rules", () => {
+    // Contains "bot" — must NOT be classified as a crawler.
+    expect(classifyClient("PerplexityBot/1.0")).toBe("agent");
+    expect(classifyClient("ChatGPT-User/1.0")).toBe("agent");
+    expect(classifyClient("Claude-User/1.0")).toBe("agent");
+    // Ships a full browser string — must NOT be classified as a browser.
+    expect(
+      classifyClient("Mozilla/5.0 (compatible; anthropic-ai/1.0; +http://x)"),
+    ).toBe("agent");
+    expect(classifyClient("Cursor/0.42 Chrome/120")).toBe("agent");
+  });
+
+  it("keeps crawlers out of the install count", () => {
+    expect(classifyClient("Googlebot/2.1")).toBe("bot");
+    expect(classifyClient("Mozilla/5.0 (compatible; bingbot/2.0)")).toBe("bot");
+    expect(classifyClient("facebookexternalhit/1.1")).toBe("bot");
+  });
+
+  it("recognises a person looking at the JSON in a tab", () => {
+    expect(
+      classifyClient(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36",
+      ),
+    ).toBe("browser");
+  });
+
+  it("falls back rather than guessing", () => {
+    expect(classifyClient("something-nobody-has-seen/1.0")).toBe("unknown");
+  });
+});

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -1,0 +1,202 @@
+/**
+ * Server-side PostHog capture — no SDK, one `fetch` to the public capture API.
+ *
+ * (No `import "server-only"`: this module is imported by Edge middleware, which
+ * is not bundled under the `react-server` condition that package resolves
+ * through. Nothing here is client-importable anyway — it reads request headers.)
+ *
+ * ## Why not `posthog-node`
+ *
+ * `posthog-node` batches events in memory and flushes on a timer, which is
+ * exactly wrong here: middleware and route handlers are serverless invocations
+ * that can be frozen the instant they return a response, so a queued batch is a
+ * dropped batch unless every call site remembers to `await posthog.shutdown()`.
+ * A single awaited POST has no queue to lose. It is also the only option that
+ * runs in Edge middleware, where `posthog-node` does not, so this file is the
+ * one capture path for *both* runtimes instead of two that drift.
+ *
+ * Cost is one HTTPS round-trip, which the caller keeps off the critical path by
+ * wrapping it in `after()`.
+ *
+ * ## Identity
+ *
+ * A browser that has already loaded posthog-js carries its distinct id in the
+ * `ph_<key>_posthog` cookie. Reading it (`distinctIdFromCookie`) is what makes a
+ * server event land on the *same person* as that visitor's client events —
+ * without it, "viewed the docs page" and "actually ran shadcn add" would be two
+ * unrelated strangers and the funnel between them could not be drawn.
+ *
+ * A CLI or an agent has no cookie and never will. Those get a stable
+ * pseudonymous id derived from IP + user-agent, and are sent with
+ * `$process_person_profile: false` so they are counted without creating a person
+ * profile for every bot that crawls the registry.
+ */
+
+const KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+/**
+ * `NEXT_PUBLIC_POSTHOG_HOST` is the *dashboard* host (`us.posthog.com`), which
+ * is a different hostname from the *ingestion* one (`us.i.posthog.com`) — POST
+ * an event to the dashboard and it is silently discarded. Derive ingestion from
+ * the region the same way `next.config.ts` does, so one env var stays the only
+ * thing anyone has to set.
+ *
+ * Unlike the browser, this does not go through the `/ingest` proxy: there is no
+ * ad blocker between two servers, and pointing the app's own origin at itself
+ * would be a loop.
+ */
+const HOST = (process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "").includes("eu.")
+  ? "https://eu.i.posthog.com"
+  : "https://us.i.posthog.com";
+
+export type ServerEvent =
+  /**
+   * ★ The conversion event. A `shadcn add` fetch of `/r/<component>.json` — the
+   * only signal in this product that someone *installed* a component rather than
+   * looked at one. Everything else on the site is a leading indicator of this.
+   */
+  | "registry_component_fetched"
+  /**
+   * A fetch of `/r/<name>.json` for a component that does not exist — a 404.
+   *
+   * Deliberately a *separate* event rather than a `found: false` property on the
+   * one above, because middleware cannot see a response status: it fires on the
+   * way in, so without this split every 404 would land in the conversion count
+   * and any insight built on `registry_component_fetched` would silently include
+   * failed installs. Splitting keeps that number correct by default.
+   *
+   * It is also worth reading on its own. Someone running `shadcn add` against a
+   * name we do not have is the same signal as a zero-result docs search — a
+   * request for a component, written by a user who did not know they were filing
+   * one. Trimming the registry in ee250e3 left 68 such names in the wild.
+   */
+  | "registry_component_missing"
+  /** `/llms.txt` or `/llms-full.txt` — the size of the AI-agent channel. */
+  | "llms_txt_fetched"
+  /** A docs search, with its result count. Zero-result queries are the roadmap. */
+  | "docs_searched";
+
+type Props = Record<string, unknown>;
+
+/**
+ * Send one event. Never throws and never rejects — analytics must not be able to
+ * fail a registry fetch. Returns immediately as a no-op when unconfigured, so a
+ * local checkout without a PostHog key behaves exactly like one with it.
+ */
+export async function captureServer(
+  event: ServerEvent,
+  distinctId: string,
+  properties: Props = {},
+): Promise<void> {
+  // Same dev gate as the client provider: a local `pnpm dev` hitting
+  // /r/<thing>.json must not land in the install count that decides what gets
+  // built next. `pnpm build && pnpm start` sends for real.
+  if (!KEY || process.env.NODE_ENV === "development") return;
+
+  try {
+    await fetch(`${HOST}/i/v0/e/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: KEY,
+        event,
+        distinct_id: distinctId,
+        properties: {
+          ...properties,
+          // Mirrors the client's `person_profiles: "identified_only"`: count the
+          // event, don't mint a person for every crawler that hits the registry.
+          $process_person_profile: false,
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Swallowed on purpose. See the doc comment.
+  }
+}
+
+/**
+ * The visitor's posthog-js distinct id, if this request came from a browser that
+ * has already booted the client SDK. Cookie name is `ph_<projectKey>_posthog`
+ * and the value is URL-encoded JSON.
+ */
+export function distinctIdFromCookie(cookies: {
+  get(name: string): { value: string } | undefined;
+}): string | null {
+  if (!KEY) return null;
+  const raw = cookies.get(`ph_${KEY}_posthog`)?.value;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw)) as {
+      distinct_id?: string;
+    };
+    return parsed.distinct_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stable pseudonymous id for a caller with no cookie — a CLI, an agent, a bot.
+ *
+ * SHA-256 over IP + user-agent, truncated. Not reversible to an IP, stable for
+ * as long as that machine keeps the same address, which is enough to tell "forty
+ * installs" apart from "one person installing forty times" without storing
+ * anything identifying. Web Crypto, so it runs on the Edge runtime.
+ */
+export async function anonymousId(ip: string, ua: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`snap-cn:${ip}:${ua}`);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `anon:${hex}`;
+}
+
+export type ClientKind = "agent" | "bot" | "cli" | "browser" | "unknown";
+
+/**
+ * Who is on the other end of a registry fetch.
+ *
+ * This is the property that makes `registry_component_fetched` worth having:
+ * without it the number is "requests", which GoogleBot inflates and which cannot
+ * distinguish a human running `shadcn add` from Claude Code running it for them.
+ * With it you can read the install count three ways — humans, agents, and
+ * crawlers-to-ignore — which is the actual question about how this registry is
+ * being adopted.
+ *
+ * Order matters. `PerplexityBot` and `ChatGPT-User` both contain bot-ish tokens,
+ * and agents commonly run through Node, so agents are matched first, then
+ * crawlers, then generic HTTP clients, and only then browsers — because a
+ * headless agent will happily send a full `Mozilla/5.0` string.
+ */
+export function classifyClient(userAgent: string | null): ClientKind {
+  if (!userAgent) {
+    // No UA at all is almost always a script. `fetch` in Node sends none.
+    return "cli";
+  }
+  const ua = userAgent.toLowerCase();
+
+  if (
+    /claude|anthropic|chatgpt|openai|gptbot|perplexity|cursor|copilot|codeium|gemini|google-extended|cohere|you\.com|phind/.test(
+      ua,
+    )
+  ) {
+    return "agent";
+  }
+  if (/bot\b|crawler|spider|slurp|facebookexternalhit|bingpreview/.test(ua)) {
+    return "bot";
+  }
+  if (
+    /shadcn|node|undici|axios|got\/|curl|wget|bun|deno|python-requests|go-http|okhttp|libwww|httpie/.test(
+      ua,
+    )
+  ) {
+    return "cli";
+  }
+  if (/mozilla|webkit|gecko|chrome|safari|firefox|edge/.test(ua)) {
+    return "browser";
+  }
+  return "unknown";
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,10 +1,42 @@
 "use client";
 
-import { useOpenPanel } from "@openpanel/nextjs";
+import posthog from "posthog-js";
 import { useCallback } from "react";
 
-export type PreviewSurface = "hero" | "docs";
-
+/**
+ * The site's typed event vocabulary.
+ *
+ * Every event below exists to answer a question we would otherwise guess at.
+ * If you cannot name the question, do not add the event — a taxonomy nobody
+ * reads is worse than no taxonomy, because it looks like coverage.
+ *
+ *   ┌ Are we converting? ──────────────────────────────────────────────────┐
+ *   │ install_command_copied → registry_component_fetched (server-side, in │
+ *   │ middleware.ts). That ratio is the funnel. Copying a string is        │
+ *   │ intent; the registry fetch is the install. Everything else on this   │
+ *   │ list is a leading indicator of that one line.                        │
+ *   └──────────────────────────────────────────────────────────────────────┘
+ *   • What do people want?      docs_component_viewed, component_code_viewed,
+ *                               gallery_filtered, docs_searched (server) —
+ *                               zero-result searches are a component request
+ *                               in disguise.
+ *   • Is the customizer worth   component_customized, customizer_reset,
+ *     its complexity?           customized_link_shared. If nobody touches a
+ *                               control, its config line can go.
+ *   • Does the editor work?     editor_* — export failures are a bug report we
+ *                               would otherwise never receive, because the user
+ *                               just closes the tab.
+ *   • Community loop            showcase_submitted, signed_in.
+ *
+ * Deliberately NOT here: scroll depth, rage clicks, generic clicks, time on
+ * page, and web vitals — PostHog's autocapture, `$pageleave` and web-vitals
+ * config already record all of it. Hand-rolling them would be duplicate data
+ * under a second name.
+ *
+ * Also not here: preview play/pause. Previews autoplay when they scroll into
+ * view (`use-lazy-player.ts`), so a "played" event would measure scrolling
+ * under a name that reads like intent — worse than not measuring it.
+ */
 export type CtaId =
   | "hero_browse"
   | "hero_ui_badge"
@@ -16,15 +48,6 @@ type AnalyticsEvents = {
     component: string;
     package_manager: "pnpm" | "npm" | "yarn" | "bun" | "prompt";
     surface: "docs" | "landing";
-  };
-  preview_played: {
-    component: string;
-    surface: PreviewSurface;
-    trigger: "click" | "hover";
-  };
-  preview_paused: {
-    component: string;
-    surface: PreviewSurface;
   };
   component_customized: {
     component: string;
@@ -43,10 +66,58 @@ type AnalyticsEvents = {
   docs_component_viewed: {
     component: string;
   };
+
+  /**
+   * Switched a component page to the Code tab. Reading the source before
+   * installing is the shadcn-user behaviour that separates "browsing" from
+   * "evaluating", and it is the strongest on-site predictor we have of a real
+   * install short of the fetch itself.
+   */
+  component_code_viewed: {
+    component: string;
+  };
+  /** Category pill on /docs/components. Tells us which shelf people shop. */
+  gallery_filtered: {
+    category: string | null;
+    sort: string;
+  };
+
+  /** Video editor. Opened, built, exported — the whole funnel of the one part
+   * of this site that is an app rather than a document. */
+  editor_opened: Record<string, never>;
+  editor_clip_added: {
+    component: string;
+    clip_count: number;
+  };
+  editor_export_started: {
+    clip_count: number;
+  };
+  editor_export_succeeded: {
+    clip_count: number;
+    /** Wall-clock from click to downloaded file — the number a user feels. */
+    duration_ms: number;
+  };
+  editor_export_failed: {
+    clip_count: number;
+    reason: string;
+  };
+
+  showcase_submitted: Record<string, never>;
+  /**
+   * Fired once per browser per account, at the moment `identifyUser` promotes
+   * an anonymous visitor. No `provider` property: which OAuth button they used
+   * is already a row in the `accounts` table, and a copy here would be a second
+   * source of truth for a question the database answers exactly.
+   */
+  signed_in: Record<string, never>;
 };
 
+/**
+ * Fire a typed event. Safe to call before PostHog has initialised and safe to
+ * call when it is unconfigured — posthog-js queues, and an unconfigured build
+ * simply drops. No call site needs a guard.
+ */
 export function useTrackEvent() {
-  const op = useOpenPanel();
   return useCallback(
     <E extends keyof AnalyticsEvents>(
       event: E,
@@ -54,8 +125,36 @@ export function useTrackEvent() {
         ? []
         : [AnalyticsEvents[E]]
     ) => {
-      op.track(event, args[0] as Record<string, unknown> | undefined);
+      posthog.capture(event, args[0] as Record<string, unknown> | undefined);
     },
-    [op],
+    [],
   );
+}
+
+/**
+ * Attach the signed-in identity to the person PostHog has been recording
+ * anonymously, so their pre-signup browsing joins up with everything after.
+ *
+ * Self-guarding, because the only place that knows someone is signed in is a
+ * server-rendered page that re-renders on every visit — there is no "on sign-in"
+ * moment on the client to hook. `identify` merges the anonymous history the
+ * first time and is wasted requests every time after, so compare against the id
+ * PostHog is already using and return whether this call was the transition.
+ * That boolean is the `signed_in` trigger.
+ *
+ * `get_distinct_id()` is safe before `init` (persistence is optional-chained),
+ * so an unconfigured build takes this path without throwing.
+ */
+export function identifyUser(
+  userId: string,
+  properties?: { email?: string; name?: string },
+): boolean {
+  if (posthog.get_distinct_id() === userId) return false;
+  posthog.identify(userId, properties);
+  return true;
+}
+
+/** Clear the identity on sign-out so a shared machine doesn't merge two people. */
+export function resetUser() {
+  posthog.reset();
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,118 @@
+import { after, type NextRequest, NextResponse } from "next/server";
+import { INSTALL_ALL_NAMES } from "@/config/site";
+import {
+  anonymousId,
+  captureServer,
+  classifyClient,
+  distinctIdFromCookie,
+} from "@/lib/analytics-server";
+
+/**
+ * Every component that actually exists, from the same manifests the registry is
+ * built from — so a name can never be live here and missing there.
+ *
+ * Middleware runs *before* the static file is served and only ever sees the
+ * request, so a fetch of a component we do not have is indistinguishable from a
+ * real install unless we check the name ourselves. Both manifests together are
+ * ~17KB, which is nothing against the Edge bundle limit.
+ */
+const KNOWN_COMPONENTS = new Set(INSTALL_ALL_NAMES);
+
+/**
+ * Tracks the two things that happen *outside the browser*, and are therefore
+ * invisible to every client-side analytics tool.
+ *
+ * ## Why this file exists
+ *
+ * snap-cn's product is not the website. The website is a brochure; the product
+ * ships when someone runs
+ *
+ *     npx shadcn@latest add https://snapcn.dev/r/orbit-gallery.json
+ *
+ * which is a plain GET to `/r/orbit-gallery.json` from a terminal. No JS, no
+ * cookie, no pageview. Before this file, the closest thing we had to a
+ * conversion metric was `install_command_copied` — "someone put a string on
+ * their clipboard" — and the gap between that and an actual install was
+ * unmeasured. Copy-to-install is the single most important ratio in this repo
+ * and it needed a server to observe it.
+ *
+ * The second thing is `/llms.txt`, which is fetched almost exclusively by coding
+ * agents. Pair it with the `client` property on the registry event and you can
+ * read what share of installs an AI agent performed rather than a human — for a
+ * shadcn registry in 2026 that is a channel, not a curiosity.
+ *
+ * ## Cost
+ *
+ * The matcher is three paths. Middleware does not run on the landing page, the
+ * docs, `/_next/*`, or any other request, so this adds nothing to the site's
+ * latency. On the paths it does match, `after()` runs the capture once the
+ * response has already been handed back, so the CLI waits on nothing either.
+ */
+
+/**
+ * `/r/<name>.json` → `<name>`, or null if this is not a component fetch.
+ *
+ * `registry.json` is excluded deliberately: it is the whole-registry manifest
+ * the shadcn CLI resolves *before* it fetches the component, so counting it
+ * would put a phantom component named "registry" at the top of the install
+ * chart and inflate the total by one on every real install. (Verified against a
+ * running build — the CLI requests both.)
+ */
+function componentFromPath(pathname: string): string | null {
+  const match = /^\/r\/([a-z0-9-]+)\.json$/.exec(pathname);
+  if (!match || match[1] === "registry") return null;
+  return match[1];
+}
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const { pathname } = request.nextUrl;
+
+  after(async () => {
+    const ua = request.headers.get("user-agent");
+    const client = classifyClient(ua);
+
+    // A browser that already booted posthog-js hands us its identity in a
+    // cookie, which stitches this event onto the same person as their pageviews.
+    // A CLI has no cookie and gets a pseudonymous hash instead.
+    const distinctId =
+      distinctIdFromCookie(request.cookies) ??
+      (await anonymousId(
+        request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+          "unknown",
+        ua ?? "none",
+      ));
+
+    const shared = {
+      client,
+      user_agent: ua ?? "",
+      referrer: request.headers.get("referer") ?? "",
+      $current_url: request.nextUrl.href,
+    };
+
+    if (pathname === "/llms.txt" || pathname === "/llms-full.txt") {
+      await captureServer("llms_txt_fetched", distinctId, {
+        ...shared,
+        file: pathname.slice(1),
+      });
+      return;
+    }
+
+    const component = componentFromPath(pathname);
+    if (component) {
+      await captureServer(
+        KNOWN_COMPONENTS.has(component)
+          ? "registry_component_fetched"
+          : "registry_component_missing",
+        distinctId,
+        { ...shared, component },
+      );
+    }
+  });
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/r/:path*", "/llms.txt", "/llms-full.txt"],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,28 @@ import type { NextConfig } from "next";
 
 const withMDX = createMDX();
 
+/**
+ * PostHog ingestion, proxied through this origin (see app/posthog-provider.tsx
+ * for why: our audience is frontend developers, and a third-party analytics
+ * hostname is blocked for a large share of them).
+ *
+ * `NEXT_PUBLIC_POSTHOG_HOST` is the dashboard host and decides the region —
+ * `https://us.posthog.com` or `https://eu.posthog.com`. The ingestion and static
+ * hosts are derived from it, so switching region is one env var, not three.
+ */
+const POSTHOG_REGION = (process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "").includes(
+  "eu.",
+)
+  ? "eu"
+  : "us";
+const POSTHOG_INGEST = `https://${POSTHOG_REGION}.i.posthog.com`;
+const POSTHOG_ASSETS = `https://${POSTHOG_REGION}-assets.i.posthog.com`;
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // PostHog's endpoints are sensitive to a trailing-slash redirect in front of
+  // them; Next would otherwise rewrite `/ingest/e/` and then 308 it.
+  skipTrailingSlashRedirect: true,
   // Remotion's server packages are Node-only and ship native binaries (esbuild +
   // the platform-specific @remotion/compositor-*). They must NOT be bundled by
   // Turbopack/webpack — keep them external so they're require()'d at runtime in
@@ -17,6 +37,16 @@ const nextConfig: NextConfig = {
   ],
   turbopack: {
     root: __dirname,
+  },
+  async rewrites() {
+    return [
+      // The SDK bundle + recorder script. Separate host from ingestion.
+      {
+        source: "/ingest/static/:path*",
+        destination: `${POSTHOG_ASSETS}/static/:path*`,
+      },
+      { source: "/ingest/:path*", destination: `${POSTHOG_INGEST}/:path*` },
+    ];
   },
   // Rendered demos always ship to the SAME path (`/demos/<slug>.mp4`), so a
   // browser that has one will happily keep replaying it after the file underneath

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.2",
     "@base-ui/react": "^1.3.0",
-    "@openpanel/nextjs": "^1.0.13",
     "@paper-design/shaders-react": "0.0.76",
     "@remotion/bundler": "4.0.473",
     "@remotion/google-fonts": "4.0.473",
@@ -56,6 +55,7 @@
     "nuqs": "^2.8.9",
     "p-limit": "^6.2.0",
     "postgres": "^3.4.9",
+    "posthog-js": "^1.413.3",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@openpanel/nextjs':
-        specifier: ^1.0.13
-        version: 1.5.1(next@16.2.2(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@paper-design/shaders-react':
         specifier: 0.0.76
         version: 0.0.76(@types/react@19.2.17)(react@19.2.4)
@@ -101,6 +98,9 @@ importers:
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
+      posthog-js:
+        specifier: ^1.413.3
+        version: 1.413.3(preact-render-to-string@6.5.11(preact@10.24.3))
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1387,19 +1387,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@openpanel/nextjs@1.5.1':
-    resolution: {integrity: sha512-60vhKw29weFWmwntx/cSIYU1TcwNzRykeg8P70onr3jzeyMGsEd78d/wgF5Mp/NIxQDN0IT4LneS6hIDIyrTpw==}
-    peerDependencies:
-      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@openpanel/sdk@1.3.1':
-    resolution: {integrity: sha512-mQ5xaBUGXnyRg3qYxwnbVaUYyW7w8u+munrWk/ClnqxEeR2j+FYPiA6noHbHMCFC2aZutYD5OoRzEvw3FBNFxw==}
-
-  '@openpanel/web@1.4.1':
-    resolution: {integrity: sha512-DgUWeocZw+b57YiJjefZPg+6sceR7TdOF8x7Ut75lu3CwcwqGi5jZNPXjikNemGL37aNWXCB4buhcoNan2j7RA==}
-
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
@@ -1421,6 +1408,15 @@ packages:
 
   '@paper-design/shaders@0.0.76':
     resolution: {integrity: sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==}
+
+  '@posthog/browser-common@0.4.0':
+    resolution: {integrity: sha512-W9DCGVks15docUMPvJ2nd8NS16Gn74bsGWuaeg31beEKFSjdW8wvnQ1ETY6WSql5pYxZb3GdJmEUZVVstKSrBQ==}
+
+  '@posthog/core@1.46.9':
+    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
+
+  '@posthog/types@1.402.2':
+    resolution: {integrity: sha512-ZZTiS4dLwF4/D0YTzS3gGSLFnhuNOY5yu4d9VGS9trGe5GW6FjIXo20p18K5BPW2RZSYSld8sdnSAY3AUXleUQ==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -1996,12 +1992,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rrweb/types@2.0.0-alpha.20':
-    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
-
-  '@rrweb/utils@2.1.0':
-    resolution: {integrity: sha512-hU7MT3TSdD+Do7FmMoHrBfPevFCheN5vo2mn97Y4vbXuwemopAmo8dqo5KJeMaA6oQQt7FinHJ0Xqb7k68Ci6Q==}
-
   '@rspack/binding-darwin-arm64@1.7.6':
     resolution: {integrity: sha512-NZ9AWtB1COLUX1tA9HQQvWpTy07NSFfKBU8A6ylWd5KH8AePZztpNgLLAVPTuNO4CZXYpwcoclf8jG/luJcQdQ==}
     cpu: [arm64]
@@ -2339,9 +2329,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/css-font-loading-module@0.0.7':
-    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
-
   '@types/culori@4.0.1':
     resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
 
@@ -2421,6 +2408,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2518,9 +2508,6 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xstate/fsm@1.6.5':
-    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
-
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -2612,10 +2599,6 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  base64-arraybuffer@1.0.2:
-    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
-    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
@@ -2773,6 +2756,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -2933,6 +2919,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -3259,6 +3248,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4169,9 +4161,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
   motion-dom@12.42.2:
     resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
 
@@ -4456,6 +4445,9 @@ packages:
     resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
+  posthog-js@1.413.3:
+    resolution: {integrity: sha512-UoAymtZYVr84Ldp0ITXmlK4Q3GE8vU7GW8wC+aCput5RrKVJ8wkAPc12n3ElmKRlvLL+oD+Fotjc7n3wYG0RGQ==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -4467,6 +4459,14 @@ packages:
 
   preact@10.24.3:
     resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
@@ -4490,6 +4490,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4682,15 +4685,6 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
-
-  rrdom@2.1.0:
-    resolution: {integrity: sha512-d7oaIHzwffxI74UJMZDGq/f97/Yfm3QX4CcTIlQelt2HsLavItLjp8x8nQ0g9Pet5+5wG1RGr9yvsxb1gJlo8A==}
-
-  rrweb-snapshot@2.1.0:
-    resolution: {integrity: sha512-CFjUKWlO+Dl72gk8qwcDcNE/Pj9yr6IvGRAiRAx12pmJaSWaOKFoFgpQQ1j/mW0WKwEZXbHnMJL8M92gIsdwUQ==}
-
-  rrweb@2.0.0-alpha.20:
-    resolution: {integrity: sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -5234,6 +5228,12 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -6238,21 +6238,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openpanel/nextjs@1.5.1(next@16.2.2(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@openpanel/web': 1.4.1
-      next: 16.2.2(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@openpanel/sdk@1.3.1': {}
-
-  '@openpanel/web@1.4.1':
-    dependencies:
-      '@openpanel/sdk': 1.3.1
-      '@rrweb/types': 2.0.0-alpha.20
-      rrweb: 2.0.0-alpha.20
-
   '@orama/orama@3.1.18': {}
 
   '@oxc-project/types@0.138.0': {}
@@ -6267,6 +6252,17 @@ snapshots:
       '@types/react': 19.2.17
 
   '@paper-design/shaders@0.0.76': {}
+
+  '@posthog/browser-common@0.4.0':
+    dependencies:
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+
+  '@posthog/core@1.46.9':
+    dependencies:
+      '@posthog/types': 1.402.2
+
+  '@posthog/types@1.402.2': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -6854,10 +6850,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rrweb/types@2.0.0-alpha.20': {}
-
-  '@rrweb/utils@2.1.0': {}
-
   '@rspack/binding-darwin-arm64@1.7.6':
     optional: true
 
@@ -7134,8 +7126,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/css-font-loading-module@0.0.7': {}
-
   '@types/culori@4.0.1': {}
 
   '@types/d3-array@3.2.2': {}
@@ -7215,6 +7205,9 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7348,8 +7341,6 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xstate/fsm@1.6.5': {}
-
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -7414,8 +7405,6 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
-
-  base64-arraybuffer@1.0.2: {}
 
   baseline-browser-mapping@2.10.40: {}
 
@@ -7558,6 +7547,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.50.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -7682,6 +7673,10 @@ snapshots:
       dequal: 2.0.3
 
   diff@8.0.4: {}
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dot-prop@6.0.1:
     dependencies:
@@ -8049,6 +8044,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.9: {}
 
   figures@6.1.0:
     dependencies:
@@ -9143,8 +9140,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mitt@3.0.1: {}
-
   motion-dom@12.42.2:
     dependencies:
       motion-utils: 12.39.0
@@ -9390,6 +9385,21 @@ snapshots:
 
   postgres@3.4.9: {}
 
+  posthog-js@1.413.3(preact-render-to-string@6.5.11(preact@10.24.3)):
+    dependencies:
+      '@posthog/browser-common': 0.4.0
+      '@posthog/core': 1.46.9
+      '@posthog/types': 1.402.2
+      core-js: 3.50.0
+      dompurify: 3.4.13
+      fflate: 0.4.9
+      preact: 10.29.8(preact-render-to-string@6.5.11(preact@10.24.3))
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
   powershell-utils@0.1.0: {}
 
   preact-render-to-string@6.5.11(preact@10.24.3):
@@ -9397,6 +9407,10 @@ snapshots:
       preact: 10.24.3
 
   preact@10.24.3: {}
+
+  preact@10.29.8(preact-render-to-string@6.5.11(preact@10.24.3)):
+    optionalDependencies:
+      preact-render-to-string: 6.5.11(preact@10.24.3)
 
   pretty-ms@9.3.0:
     dependencies:
@@ -9420,6 +9434,8 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9683,25 +9699,6 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
-
-  rrdom@2.1.0:
-    dependencies:
-      rrweb-snapshot: 2.1.0
-
-  rrweb-snapshot@2.1.0:
-    dependencies:
-      postcss: 8.5.16
-
-  rrweb@2.0.0-alpha.20:
-    dependencies:
-      '@rrweb/types': 2.0.0-alpha.20
-      '@rrweb/utils': 2.1.0
-      '@types/css-font-loading-module': 0.0.7
-      '@xstate/fsm': 1.6.5
-      base64-arraybuffer: 1.0.2
-      mitt: 3.0.1
-      rrdom: 2.1.0
-      rrweb-snapshot: 2.1.0
 
   run-applescript@7.1.0: {}
 
@@ -10252,6 +10249,10 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-namespaces@2.0.1: {}
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   webidl-conversions@4.0.2: {}
 


### PR DESCRIPTION
Replaces OpenPanel with PostHog and adds the server-side half of the funnel, which is where this product actually converts.

## Why

The website is a brochure. The product ships when someone runs `shadcn add`, which is a plain GET to `/r/<component>.json` from a terminal — no JS, no cookie, no pageview. Before this, the closest thing to a conversion metric was `install_command_copied`, i.e. "someone put a string on their clipboard", and the gap between that and a real install was unmeasured.

## What's in it

**Server events** (`middleware.ts` + `lib/analytics-server.ts`) — a plain `fetch` to the capture API, no SDK, so it runs in Edge middleware and can't lose a queued batch when the function freezes.

| Event | Signal |
|---|---|
| `registry_component_fetched` | ★ the install |
| `registry_component_missing` | `shadcn add` against a name we don't have — a component request in disguise |
| `llms_txt_fetched` | the AI-agent channel |
| `docs_searched` | zero-result queries are the roadmap |

Registry fetches carry a `client` property (`agent` / `bot` / `cli` / `browser`) so the install count can be read three ways instead of being inflated by crawlers. Browser requests reuse the posthog-js cookie, so a visitor's server events land on the same person as their client events; a CLI gets a SHA-256 pseudonym over IP + UA.

**Client events** (`lib/analytics.ts`) — every event declared with the question it answers. Autocapture, pageviews, pageleave, web vitals, exceptions and session replay are SDK config in `app/posthog-provider.tsx`, not hand-rolled.

**Identity** — sign-in now calls `identifyUser()`, so pre-signup browsing joins up with the account instead of being two unrelated strangers. `resetUser()` on sign-out so a shared machine doesn't merge two people.

**Header GitHub button** — reports `cta_clicked` like every other CTA, instead of leaving a `data-track` attribute for autocapture to notice.

**Removed** — `preview_played` / `preview_paused`. Previews autoplay when they scroll into view, so those would have measured scrolling under a name that reads like intent.

## Notes

- Ingestion is proxied through `/ingest` (rewrite in `next.config.ts`). This site's audience is frontend developers; a third-party analytics hostname is blocked for a large share of them, and that's exactly the traffic worth measuring.
- Nothing is sent from `pnpm dev` — both the provider and the server capture gate on `NODE_ENV`. Verify with `pnpm build && pnpm start`.
- `NEXT_PUBLIC_POSTHOG_KEY` is unset-safe: no key means no tracker and every call site becomes a no-op, so a fork needs nothing.
- Region is one env var. `NEXT_PUBLIC_POSTHOG_HOST` picks it; the ingest and asset hosts are derived.

## Verification

`pnpm install --frozen-lockfile && next build` in a clean worktree at this commit — passes, middleware registered. `vitest run lib/__tests__/analytics-server.test.ts` — 5 passed (user-agent classification).