### PR TITLE
Follow the repo to its new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ device frames, captions — as components you install with the shadcn CLI and ow
 </p>
 
 <p>
-<img alt="MIT License" src="https://img.shields.io/github/license/snapcndev/snapcn.dev?style=flat-square&color=blue">
-<img alt="Stars" src="https://img.shields.io/github/stars/snapcndev/snapcn.dev?style=flat-square&color=blue">
+<img alt="MIT License" src="https://img.shields.io/github/license/snapcndev/snapcn?style=flat-square&color=blue">
+<img alt="Stars" src="https://img.shields.io/github/stars/snapcndev/snapcn?style=flat-square&color=blue">
 <img alt="Remotion 4" src="https://img.shields.io/badge/Remotion-4.0-blue?style=flat-square">
 </p>
 
@@ -102,7 +102,7 @@ rules above — so your agent picks the right component and budgets the timeline
 `interpolate()` calls:
 
 ```bash
-npx skills add snapcndev/snapcn.dev --skill snapcn --yes
+npx skills add snapcndev/snapcn --skill snapcn --yes
 ```
 
 Agents that read context files instead can pull [`llms.txt`](https://snapcn.dev/llms.txt) or the
@@ -118,7 +118,7 @@ full corpus at [`llms-full.txt`](https://snapcn.dev/llms-full.txt).
 ## Contributing
 
 Issues and PRs welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md). Missing a component you need?
-[Open an issue](https://github.com/snapcndev/snapcn.dev/issues) — the roadmap is mostly whatever
+[Open an issue](https://github.com/snapcndev/snapcn/issues) — the roadmap is mostly whatever
 people ask for.
 
 ## Author

--- a/app/(home)/components/sections/faq.tsx
+++ b/app/(home)/components/sections/faq.tsx
@@ -58,7 +58,7 @@ export const FAQ_ITEMS: { q: string; a: string }[] = [
   },
   {
     q: "Does it work with Claude Code and other AI agents?",
-    a: "snapcn ships an agent skill — the component catalog with props and durations, the motion-design rules, and the anti-patterns — installable with npx skills add snapcndev/snapcn.dev. Your agent then picks the right component and budgets the timeline without you pasting context every time.",
+    a: "snapcn ships an agent skill — the component catalog with props and durations, the motion-design rules, and the anti-patterns — installable with npx skills add snapcndev/snapcn. Your agent then picks the right component and budgets the timeline without you pasting context every time.",
   },
 ];
 

--- a/config/site.ts
+++ b/config/site.ts
@@ -8,7 +8,7 @@ export const PEACH = "#FFB38E";
 export const LAVENDER = "#D4B3FF";
 export const MINT = "#A1EEBD";
 
-export const GITHUB_URL = "https://github.com/snapcndev/snapcn.dev";
+export const GITHUB_URL = "https://github.com/snapcndev/snapcn";
 
 /**
  * The one place the install command is spelled.

--- a/content/docs/getting-started/agent-skill.mdx
+++ b/content/docs/getting-started/agent-skill.mdx
@@ -12,11 +12,11 @@ your additions to match the library — without you pasting context every time.
 
 ## Install with skills.sh
 
-The skill lives in the [`skills/`](https://github.com/snapcndev/snapcn.dev/tree/main/skills) folder of
+The skill lives in the [`skills/`](https://github.com/snapcndev/snapcn/tree/main/skills) folder of
 the snapcn repo. Install it with the [`skills`](https://skills.sh) CLI:
 
 ```bash
-npx skills add snapcndev/snapcn.dev
+npx skills add snapcndev/snapcn
 ```
 
 This finds the `snapcn` skill and installs it into your agent (for Claude Code:
@@ -26,16 +26,16 @@ This finds the `snapcn` skill and installs it into your agent (for Claude Code:
 
 ```bash
 # Install straight to the snapcn skill, no prompts
-npx skills add snapcndev/snapcn.dev --skill snapcn --yes
+npx skills add snapcndev/snapcn --skill snapcn --yes
 
 # Install globally (available in every project)
-npx skills add snapcndev/snapcn.dev --skill snapcn -g
+npx skills add snapcndev/snapcn --skill snapcn -g
 
 # Target a specific agent
-npx skills add snapcndev/snapcn.dev -a claude-code
+npx skills add snapcndev/snapcn -a claude-code
 
 # Just list what's available in the repo
-npx skills add snapcndev/snapcn.dev --list
+npx skills add snapcndev/snapcn --list
 ```
 
 ### Use without installing
@@ -43,7 +43,7 @@ npx skills add snapcndev/snapcn.dev --list
 To try it for a single session without writing files:
 
 ```bash
-npx skills use snapcndev/snapcn.dev@snap-cn | claude
+npx skills use snapcndev/snapcn@snap-cn | claude
 ```
 
 ## What's inside

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -33,4 +33,4 @@ notes for that group.
 <DocsIndex />
 
 Every component is MIT licensed, and the code is
-[on GitHub](https://github.com/snapcndev/snapcn.dev).
+[on GitHub](https://github.com/snapcndev/snapcn).

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,4 @@
-const GITHUB_REPO = "snapcndev/snapcn.dev";
+const GITHUB_REPO = "snapcndev/snapcn";
 
 /**
  * Fetches the repository star count from the GitHub REST API.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://snapcn.dev",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snapcndev/snapcn.dev.git"
+    "url": "https://github.com/snapcndev/snapcn.git"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The repo was renamed from `snapcn.dev` to `snapcn`. GitHub redirects the old path forever, so nothing is broken — but the badges, `npx skills add` commands, issue links, package.json repository URL and `lib/github.ts` were all still spelling the old name.

16 references across 7 files. Tests 620 passing, build clean.