### PR TITLE
Stop the Remotion packages taking down unrelated API routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ AUTH_FACEBOOK_SECRET=""
 
 # ─── Showcase moderation ────────────────────────────────────────────────────
 # Comma-separated emails allowed to open /docs/showcase/admin and approve/reject.
-ADMIN_EMAILS="admin@simplifyingai.com"
+ADMIN_EMAILS="hello@snapcn.dev"
 
 # ─── Rendering & storage (self-hosted / Coolify) ────────────────────────────
 # Where the render pipeline keeps its files. All three default to the OS temp

--- a/lib/server/bundle.ts
+++ b/lib/server/bundle.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { bundle } from "@remotion/bundler";
 import { remotionWebpackAlias } from "./remotion-aliases";
 
 /**
@@ -26,15 +25,28 @@ export function getServeUrl(): Promise<string> {
       return PREBUNDLED_DIR;
     }
     try {
-      // Imported here, not at module scope. This file is reachable from the
-      // /api/render route, and `@remotion/tailwind-v4` pulls in the native
-      // `@tailwindcss/oxide` binary — which Turbopack cannot place in an ESM
-      // chunk, so a static import fails the whole site build. It is only ever
-      // needed on this Node-side path.
-      const { enableTailwind } = await import(
-        /* webpackIgnore: true */ /* turbopackIgnore: true */
-        "@remotion/tailwind-v4"
-      );
+      // Both imported here, not at module scope, and for the same reason: they
+      // pull native binaries (`@tailwindcss/oxide`, and `@rspack/binding` via
+      // `@remotion/bundler` -> `@rspack/core`).
+      //
+      // `@remotion/bundler` was a top-level import until it took the site down.
+      // A serverless deploy does not trace those `.node` files into the
+      // function, so requiring the module throws at *evaluation* — and this
+      // file is reachable from `/api/audio` and `/api/showcase` through
+      // cleanup -> render-queue -> render -> here. Two routes that never render
+      // anything returned 500 because the renderer failed to load beside them.
+      // Deferring the import means only a request that actually bundles can hit
+      // it, and it fails as a job error instead of taking the route down.
+      const [{ enableTailwind }, { bundle }] = await Promise.all([
+        import(
+          /* webpackIgnore: true */ /* turbopackIgnore: true */
+          "@remotion/tailwind-v4"
+        ),
+        import(
+          /* webpackIgnore: true */ /* turbopackIgnore: true */
+          "@remotion/bundler"
+        ),
+      ]);
       return await bundle({
         entryPoint: ENTRY_POINT,
         // Webpack doesn't read tsconfig `paths`; teach it every alias the

--- a/lib/server/render.ts
+++ b/lib/server/render.ts
@@ -1,10 +1,22 @@
 import "server-only";
-import {
-  makeCancelSignal,
-  renderMedia,
-  selectComposition,
-} from "@remotion/renderer";
 import { getServeUrl } from "./bundle";
+
+/**
+ * Loaded on demand, never at module scope.
+ *
+ * `@remotion/renderer` ships a native compositor binary. A serverless deploy
+ * does not trace those `.node` files into the function, so importing this
+ * module at the top level throws at *evaluation* — and because bundlers hoist
+ * the whole chunk, that took down every route that merely sat downstream of
+ * `render-queue` (`/api/audio`, `/api/showcase`, `/api/projects`), none of
+ * which render anything. Behind a function call, only a real render can hit it.
+ */
+function loadRenderer() {
+  return import(
+    /* webpackIgnore: true */ /* turbopackIgnore: true */
+    "@remotion/renderer"
+  );
+}
 
 /**
  * Server-side MP4 render of any registered Remotion composition (
@@ -53,6 +65,8 @@ export async function renderComposition({
     throw new Error("Render aborted before it started");
   }
 
+  const { makeCancelSignal, renderMedia, selectComposition } =
+    await loadRenderer();
   const serveUrl = await getServeUrl();
 
   const composition = await selectComposition({


### PR DESCRIPTION
`/api/audio`, `/api/showcase` and `/api/projects` return 500 in production. None of
them render anything. The production log names it:

```
Failed to load external module @remotion/bundler:
  Cannot find module '@rspack/binding'
```

`@remotion/bundler` pulls `@rspack/core`, whose native binding is not traced into a
serverless function, so the module throws at **evaluation**. Those routes reach it
through `cleanup` → `render-queue` → `render` → `bundle`, and a throw there kills the
whole chunk before any handler runs. Locally the same request is a clean 400, which is
why it never appeared in dev.

Both packages now load inside the function that uses them, the way
`@remotion/tailwind-v4` already did.

### Effect

- `/api/audio`, `/api/showcase`, `/api/projects` work again.
- `/api/render` returns real 400s instead of 500s.
- Soundtrack upload works again, so exports stop silently dropping audio.

### Verified

- `pnpm build` passes; all API routes present in the output.
- Full local render **with audio**, before and after: `ffprobe` shows `h264` + `aac`
  2-channel. No regression.
- Production 500s reproduced and traced to the exact module via runtime logs.

### What this does NOT fix

Rendering still cannot run on a serverless deploy: `renderMedia` needs a headless
browser, the job registry is an in-process `Map` that does not survive between
invocations, and the work dirs are not shared — so an uploaded soundtrack is not
visible to the render that needs it. This stops the collateral damage only. Moving
`/api/render` and `/api/audio` to a long-lived box (which `.env.example` already
documents) or to Remotion Lambda is the actual fix, and is not attempted here.

Second commit is a one-line placeholder correction in `.env.example`.
