### PR TITLE
Clean up error tracking, and measure the renderer

### DIFF
--- a/app/(home)/components/sections/showcase-carousel.tsx
+++ b/app/(home)/components/sections/showcase-carousel.tsx
@@ -221,7 +221,20 @@ export function ShowcaseCarousel() {
     };
 
     layout();
-    const ro = new ResizeObserver(layout);
+    // Deferred a frame for the same reason the theme observer below is, plus
+    // one this observer has on its own: `layout` writes `style.width` on the
+    // cards and `--wall-span` on `stage` — the element being observed. Writing
+    // to the observed element from inside its own callback is what raises
+    // "ResizeObserver loop completed with undelivered notifications", and it
+    // was the single loudest entry in error tracking. The browser recovers by
+    // re-delivering next frame, so this only ever cost us a noisy digest, but
+    // the synchronous read-after-write inside the callback was real work in the
+    // resize path. One rAF hop removes both.
+    let resizeFrame = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(layout);
+    });
     ro.observe(stage);
     // The theme toggle swaps both colours out from under the canvas and fires
     // nothing a ResizeObserver would hear.
@@ -245,6 +258,7 @@ export function ShowcaseCarousel() {
       attributeFilter: ["class"],
     });
     return () => {
+      cancelAnimationFrame(resizeFrame);
       ro.disconnect();
       themed.disconnect();
     };

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
+import { anonymousId, distinctIdFromCookie } from "@/lib/analytics-server";
 import { ensureCleanupSweep } from "@/lib/server/cleanup";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import { enqueueRender, type RenderSpec } from "@/lib/server/render-queue";
@@ -77,6 +78,13 @@ export async function POST(request: NextRequest) {
     }
     throw err;
   }
+
+  // Read here, not in the queue: the render runs detached and by the time it
+  // starts there is no request left to take a cookie from. This is what joins a
+  // render to the person who opened the editor.
+  spec.distinctId =
+    distinctIdFromCookie(request.cookies) ??
+    (await anonymousId(ip, request.headers.get("user-agent") ?? ""));
 
   const jobId = enqueueRender(spec);
   return NextResponse.json({ jobId }, { status: 202 });

--- a/app/posthog-provider.tsx
+++ b/app/posthog-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CaptureResult } from "posthog-js";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useEffect } from "react";
@@ -73,10 +74,62 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       loaded: (ph) => {
         if (process.env.NODE_ENV === "development") ph.debug();
       },
-      before_send: (event) =>
-        process.env.NODE_ENV === "development" ? null : event,
+      before_send: (event) => {
+        if (process.env.NODE_ENV === "development") return null;
+        // Error tracking is only worth reading if everything in it is
+        // actionable. Three classes of noise are not — see `isNoise`.
+        if (event?.event === "$exception" && isNoise(event)) return null;
+        return event;
+      },
     });
   }, []);
 
   return <PHProvider client={posthog}>{children}</PHProvider>;
+}
+
+/**
+ * Exceptions that are reported but are not bugs in this app.
+ *
+ * The weekly digest was 222 exceptions, and ~170 of them were these three. A
+ * digest nobody can act on is a digest nobody opens, which costs us the real
+ * errors sitting underneath.
+ *
+ * Each entry is dropped for a stated reason. Nothing goes in this list because
+ * it is merely frequent.
+ */
+const NOISE = [
+  // The browser telling us a ResizeObserver callback outlasted its frame. It
+  // is a notification, not a failure: the observation is re-delivered on the
+  // next frame and nothing is lost. Ours is rAF-deferred (see
+  // showcase-carousel), but third-party widgets raise it too and we cannot fix
+  // those.
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+  // posthog-js aborting its own request. The SDK already downgrades this to a
+  // console warning internally; it only reaches error tracking because the
+  // rejected fetch surfaces as an unhandled rejection, which
+  // `capture_exceptions` picks up. An analytics beacon that did not arrive is
+  // not an application error — and reporting it means a flaky network becomes
+  // a wall of exceptions.
+  "PostHog request timed out",
+  // A <video> whose `src` changed or whose element was removed while the media
+  // was still loading. That is the normal life of a lazy player and a
+  // carousel: the user scrolls away mid-fetch and the browser abandons it.
+  "The fetching process for the media resource was aborted",
+] as const;
+
+function isNoise(event: CaptureResult): boolean {
+  const props = event.properties ?? {};
+  const list = props.$exception_list;
+  const messages: string[] = [
+    typeof props.$exception_message === "string"
+      ? props.$exception_message
+      : "",
+    ...(Array.isArray(list)
+      ? list.map((e: { value?: unknown }) =>
+          typeof e?.value === "string" ? e.value : "",
+        )
+      : []),
+  ];
+  return messages.some((m) => NOISE.some((n) => m.includes(n)));
 }

--- a/components/video-editor/video-timeline.tsx
+++ b/components/video-editor/video-timeline.tsx
@@ -168,6 +168,8 @@ function EmptyState() {
  * a network that hangs must produce a video in the fallback face, not a render
  * that sits there until Remotion's timeout kills it.
  */
+const FONT_TIMEOUT_MS = 8_000;
+
 function useGoogleFont(family: string | null) {
   const [handle] = useState(() =>
     family ? delayRender(`Loading font ${family}`) : null,
@@ -189,16 +191,39 @@ function useGoogleFont(family: string | null) {
     // `document.fonts.load` resolves once the face is parsed and ready to draw
     // — which is later than the stylesheet finishing, and is the moment that
     // actually matters for a screenshot.
+    //
+    // Raced against a timer, because `.catch().finally()` only covers a promise
+    // that *settles*. A stylesheet that hangs — a blocked request, a captive
+    // portal, a font host having a bad minute — leaves both loads pending
+    // forever, `continueRender` is never reached, and Remotion kills the frame
+    // with "Timed out loading Google Font ...". That was the one entry in error
+    // tracking that was our own bug rather than browser noise.
+    //
+    // Eight seconds is well past a real font fetch and well inside Remotion's
+    // own delayRender timeout, so we always lose the race first and fall back
+    // to the system face — a video in the wrong font beats no video at all.
+    const timer = setTimeout(() => {
+      if (!cancelled) {
+        cancelled = true;
+        continueRender(handle);
+      }
+    }, FONT_TIMEOUT_MS);
+
     Promise.all([
       document.fonts.load(`400 32px "${family}"`),
       document.fonts.load(`700 32px "${family}"`),
     ])
       .catch(() => undefined)
       .finally(() => {
-        if (!cancelled) continueRender(handle);
+        if (cancelled) return;
+        cancelled = true;
+        clearTimeout(timer);
+        continueRender(handle);
       });
 
     return () => {
+      clearTimeout(timer);
+      if (cancelled) return;
       cancelled = true;
       continueRender(handle);
     };

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -74,7 +74,33 @@ export type ServerEvent =
   /** `/llms.txt` or `/llms-full.txt` — the size of the AI-agent channel. */
   | "llms_txt_fetched"
   /** A docs search, with its result count. Zero-result queries are the roadmap. */
-  | "docs_searched";
+  | "docs_searched"
+  /**
+   * A render reached the front of the queue and started.
+   *
+   * Paired with the two below so the funnel is legible: `editor_export_started`
+   * fires in the browser and can only say someone asked. These three are the
+   * only view of what the box actually did — and since the renderer moved onto
+   * hardware we own, its throughput is our problem rather than a platform's.
+   *
+   * `queued_ms` is the one to watch. It is the wait for a concurrency slot, so
+   * it stays near zero until demand passes `RENDER_MAX_CONCURRENT` and then
+   * climbs fast. That number, not CPU, is what says "buy a bigger box".
+   */
+  | "render_started"
+  /**
+   * A finished MP4. `render_ms` over `frames` gives frames-per-second on this
+   * hardware, which is the figure that decides whether the editor's length cap
+   * is still honest.
+   */
+  | "render_succeeded"
+  /**
+   * A render that did not produce a file. `reason` is the message shown to the
+   * user, `timed_out` separates a wedged Chromium from a genuine failure —
+   * they need different fixes and would otherwise be one indistinguishable
+   * number.
+   */
+  | "render_failed";
 
 type Props = Record<string, unknown>;
 

--- a/lib/server/__tests__/render-queue.test.ts
+++ b/lib/server/__tests__/render-queue.test.ts
@@ -4,7 +4,7 @@
  * Run with:  pnpm vitest run lib/server/__tests__/render-queue.test.ts
  *
  * renderComposition (real Chromium) is mocked via vi.mock so nothing real runs.
- * node:fs/promises (mkdir) is also mocked — no real filesystem side-effects.
+  * node:fs/promises (mkdir, stat) is also mocked — no real filesystem side-effects.
  *
  * --- Seam note ---
  * render-queue.ts imports renderComposition from "./render" at module load time,
@@ -40,6 +40,9 @@ vi.mock("@/lib/server/render", () => ({
 // Mock mkdir so no real fs ops happen.
 vi.mock("node:fs/promises", () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
+  // Read on the success path for the finished file's size, which rides on the
+  // render_succeeded event.
+  stat: vi.fn().mockResolvedValue({ size: 0 }),
 }));
 
 // Mock server-only so it doesn't blow up in vitest.

--- a/lib/server/render-queue.ts
+++ b/lib/server/render-queue.ts
@@ -1,8 +1,9 @@
 import "server-only";
 import { randomUUID } from "node:crypto";
-import { mkdir } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import path from "node:path";
 import pLimit from "p-limit";
+import { captureServer } from "@/lib/analytics-server";
 import { RENDER_WORK_DIR } from "./paths";
 import { renderComposition } from "./render";
 
@@ -57,6 +58,16 @@ export interface RenderSpec {
    * agnostic). The per-account quota will want the same number.
    */
   durationInFrames: number;
+  /**
+   * Who asked, for analytics only.
+   *
+   * Carried on the spec because the render runs detached from the request that
+   * created it — by the time it starts there is no cookie left to read. Without
+   * it the render events still count, but they cannot be joined to the person
+   * who opened the editor, and "did the people who exported come back" stops
+   * being answerable.
+   */
+  distinctId?: string;
 }
 
 /** Max simultaneous renders; the rest queue. Sized for the 8-vCPU box. */
@@ -155,6 +166,29 @@ async function runRender(
 
   job.status = "rendering";
 
+  // Time spent waiting for a concurrency slot, which is the number that says
+  // whether the box is big enough. Measured from enqueue, not from here.
+  const queuedMs = Date.now() - job.createdAt;
+  const startedAt = Date.now();
+  const who = spec.distinctId ?? "server:render";
+  const shared = {
+    composition: spec.compositionId,
+    frames: spec.durationInFrames,
+    has_audio: Boolean(
+      (spec.inputProps as { audio?: unknown } | undefined)?.audio,
+    ),
+    concurrency_limit: maxConcurrent(),
+  };
+  // Fire-and-forget, never awaited. `captureServer` swallows its own errors,
+  // but awaiting it would put a network round-trip between the job flipping to
+  // "rendering" and the render starting — and would let a slow analytics host
+  // hold a concurrency slot. Analytics must not be able to slow a render down,
+  // let alone fail one.
+  void captureServer("render_started", who, {
+    ...shared,
+    queued_ms: queuedMs,
+  });
+
   await mkdir(RENDER_WORK_DIR, { recursive: true });
 
   // Per-render timeout: abort stuck Chromium so a wedged render can't hold a
@@ -182,6 +216,23 @@ async function runRender(
     job.status = "done";
     job.progress = 1;
     job.outputPath = outputPath;
+
+    const renderMs = Date.now() - startedAt;
+    const bytes = await stat(outputPath)
+      .then((s) => s.size)
+      .catch(() => 0);
+    void captureServer("render_succeeded", who, {
+      ...shared,
+      queued_ms: queuedMs,
+      render_ms: renderMs,
+      bytes,
+      // Frames per second on this hardware. The figure that says whether the
+      // editor's length cap is still honest.
+      fps:
+        renderMs > 0
+          ? Math.round((spec.durationInFrames / renderMs) * 1000)
+          : 0,
+    });
   } catch (err) {
     job.status = "error";
     job.error = controller.signal.aborted
@@ -189,6 +240,13 @@ async function runRender(
       : err instanceof Error
         ? err.message
         : "Render failed";
+    void captureServer("render_failed", who, {
+      ...shared,
+      queued_ms: queuedMs,
+      render_ms: Date.now() - startedAt,
+      timed_out: controller.signal.aborted,
+      reason: job.error,
+    });
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
Two analytics changes.

## 1. The digest was 222 exceptions, ~170 unactionable

| Issue | Count | Verdict |
|---|---|---|
| `ResizeObserver loop completed with undelivered notifications` | 76 | **our bug** — fixed at source |
| `AbortError: PostHog request timed out after 60000ms` | 85 | not an app error — dropped |
| `DOMException: media resource aborted` | 9 | expected — dropped |
| `Timed out loading Google Font` | 9 | **our bug** — fixed at source |

**ResizeObserver loop** — `showcase-carousel`'s callback wrote `style.width` on the cards and
`--wall-span` on the element it observes. Writing to the observed element from inside its own
callback is what raises that error. Deferred a frame, the same treatment the theme
`MutationObserver` beside it already had.

**Font timeout** — `video-timeline` waited on `document.fonts.load` with `.catch().finally()`, which
only covers a promise that *settles*. A hanging font request leaves both loads pending,
`continueRender` is never reached, and Remotion kills the frame. Now raced against an 8s timer so it
falls back to the system face.

The other two are dropped in `before_send`, each with its reason in the code. Nothing is on that
list for being merely frequent.

Before filtering the 85 timeouts I checked the `/ingest` proxy on the new host, in case they were a
broken route after the Coolify move: `POST /ingest/e/` answers in 0.8s, same as PostHog direct.

## 2. Nothing measured the renderer

`editor_export_*` fires in the browser, so it can only say someone asked. Now that rendering runs on
hardware we own, its throughput is our problem — and nothing recorded duration, queue wait or
failure rate.

- **`render_started`** carries `queued_ms`, the wait for a concurrency slot. Near zero until demand
  passes `RENDER_MAX_CONCURRENT`, then it climbs fast. That number, not CPU, says "buy a bigger box".
- **`render_succeeded`** carries `render_ms`, `bytes` and frames-per-second on this hardware — what
  decides whether the editor's length cap is still honest, and what the showcase volume will cost.
- **`render_failed`** separates `timed_out` from a genuine failure. Different fixes, and otherwise
  one indistinguishable number.

The distinct id is read in the route and carried on the spec: the render runs detached, so by the
time it starts there is no cookie left to read. Without it the events count but can't be joined to
the person who opened the editor.

**Never awaited.** The first cut awaited them, which put a network round-trip inside the render path
and let a slow analytics host hold a concurrency slot — the queue tests caught it.

## Checks

`pnpm build` passes · **761 tests across 42 files pass** (the queue's fs mock gained `stat`, which
the success path now reads for the file size).
