### PR TITLE
Uploaded soundtracks stopped expiring out from under saved projects

### DIFF
--- a/app/api/audio/[id]/route.ts
+++ b/app/api/audio/[id]/route.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from "node:fs";
-import { stat } from "node:fs/promises";
+import { stat, utimes } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { AUDIO_WORK_DIR } from "@/lib/server/paths";
@@ -21,6 +21,31 @@ const ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
  * number of uploads on the box (which now sit for six hours). Six stats is a
  * fixed cost and no larger than the one stat this already had to do.
  */
+/**
+ * Refresh the mtime once a file is more than a tenth of its TTL old.
+ *
+ * The TTL is measured on mtime, and nothing ever moved it — so it counted from
+ * the upload rather than from the last use, and a track in daily use expired on
+ * the same schedule as one nobody touched again. Every read renews the lease
+ * now: the editor rebuilding a `blob:` it lost on reload, and the renderer
+ * pulling the file during an export.
+ *
+ * Guarded on age rather than done unconditionally because Chrome issues a range
+ * request per seek while it decodes audio. The stat is already in hand, so the
+ * common case costs one comparison and no syscall.
+ */
+const REFRESH_AFTER_MS = 30 * 60_000;
+
+async function touch(filePath: string, mtimeMs: number): Promise<void> {
+  if (Date.now() - mtimeMs < REFRESH_AFTER_MS) return;
+  try {
+    const now = new Date();
+    await utimes(filePath, now, now);
+  } catch {
+    // Losing the refresh costs a file its lease, not this request its answer.
+  }
+}
+
 async function findUpload(id: string) {
   const hits = await Promise.all(
     AUDIO_EXTS.map(async (ext) => {
@@ -58,6 +83,8 @@ export async function GET(
 
   const found = await findUpload(id);
   if (!found) return new Response("Not found", { status: 404 });
+
+  await touch(found.filePath, found.info.mtimeMs);
   const { filePath, info, type } = found;
 
   const range = request.headers.get("range");

--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { anonymousId, distinctIdFromCookie } from "@/lib/analytics-server";
+import { audioUploadExists } from "@/lib/server/audio-file";
 import { ensureCleanupSweep } from "@/lib/server/cleanup";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import { enqueueRender, type RenderSpec } from "@/lib/server/render-queue";
@@ -77,6 +78,26 @@ export async function POST(request: NextRequest) {
       );
     }
     throw err;
+  }
+
+  // A soundtrack that is not on disk any more must stop the export, not ride
+  // along in the spec. The renderer fetches `spec.audio.src` and, when it 404s,
+  // carries on and produces a perfectly good video with no sound — which the
+  // person downloading it has no way to know until they play it. An error they
+  // can act on beats a file they have to discover is wrong.
+  // `inputProps` is deliberately `Record<string, unknown>` — the queue does not
+  // know what any composition wants — so the shape is read back here rather
+  // than pretended into the type.
+  const specAudio = spec.inputProps.audio as { uploadId?: string } | null;
+  if (specAudio?.uploadId && !(await audioUploadExists(specAudio.uploadId))) {
+    return NextResponse.json(
+      {
+        error:
+          "That soundtrack is no longer available — re-upload it and try the export again.",
+        code: "audio_missing",
+      },
+      { status: 409 },
+    );
   }
 
   // Read here, not in the queue: the render runs detached and by the time it

--- a/components/video-editor/audio-track-row.tsx
+++ b/components/video-editor/audio-track-row.tsx
@@ -5,6 +5,7 @@ import {
   type Dispatch,
   type SetStateAction,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -52,6 +53,45 @@ export function AudioTrackRow({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
   const [drag, setDrag] = useState<{ x: number; from: number } | null>(null);
+
+  /**
+   * A restored track has to prove the file is still there.
+   *
+   * `src` is an object URL while the tab that uploaded it is alive, and on
+   * reload the draft rebuilds it as `/api/audio/<uploadId>` instead. If that
+   * upload has since been reclaimed the row comes back looking completely
+   * normal — name, volume, trim, the block on the timeline — with a 404 behind
+   * it, and the first anyone hears of it is silence during playback or a
+   * finished export with no sound.
+   *
+   * So: probe once, and if it is gone say so and clear the row. Losing the trim
+   * they set is worse than nothing, but not nearly as bad as keeping a control
+   * that lies about what it is going to do.
+   */
+  const probed = useRef<string | null>(null);
+  useEffect(() => {
+    const src = audio?.src;
+    if (!src || src.startsWith("blob:") || probed.current === src) return;
+    probed.current = src;
+
+    let cancelled = false;
+    void fetch(src, { method: "HEAD" })
+      .then((res) => {
+        if (cancelled || res.ok) return;
+        onChange((cur) => (cur?.src === src ? null : cur));
+        toast.error("That soundtrack is no longer available.", {
+          description:
+            "Uploads are cleared once nothing is using them. Add it again to keep it.",
+        });
+      })
+      .catch(() => {
+        // Offline or a blocked request is not proof the file is gone. Leave the
+        // row alone; the export checks again server-side before it runs.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [audio?.src, onChange]);
 
   /** How far the head can move before the file runs out under the video. */
   const maxTrim = Math.max(0, (audio?.durationSeconds ?? 0) - videoSeconds);

--- a/lib/server/__tests__/cleanup.test.ts
+++ b/lib/server/__tests__/cleanup.test.ts
@@ -39,6 +39,14 @@ vi.mock("@/lib/server/render-queue", () => ({
   deleteJob: (id: string) => deleteJob(id),
 }));
 
+// What a saved project still points at. Mocked because the real one reaches
+// Postgres, and the behaviour under test is what the sweep does with the
+// answer — including what it does when there isn't one.
+const referencedAudioIds = vi.fn(async () => new Set<string>());
+vi.mock("@/lib/server/audio-refs", () => ({
+  referencedAudioIds: () => referencedAudioIds(),
+}));
+
 import { sweepOnce } from "@/lib/server/cleanup";
 
 const NOW = 1_800_000_000_000;
@@ -64,6 +72,8 @@ beforeEach(() => {
   stat.mockReset();
   rm.mockClear();
   deleteJob.mockReset();
+  referencedAudioIds.mockReset();
+  referencedAudioIds.mockResolvedValue(new Set<string>());
   delete process.env.RENDER_FILE_TTL_MS;
   delete process.env.AUDIO_FILE_TTL_MS;
 });
@@ -147,5 +157,55 @@ describe("cleanup — the audio dir is swept at all", () => {
 
     await expect(sweepOnce()).resolves.toBeUndefined();
     expect(removed()).toEqual(["/work/renders/a.mp4"]);
+  });
+});
+
+describe("cleanup — an upload a project still points at is not scratch", () => {
+  const OLD = 12 * 60 * 60_000;
+
+  it("keeps a referenced soundtrack however old it is", async () => {
+    // The bug this is here for: a project is a Postgres row with no expiry and
+    // the file it names had a six-hour TTL, so every saved project with audio
+    // was guaranteed to lose it. The clock is not the thing that decides any
+    // more — ownership is.
+    referencedAudioIds.mockResolvedValue(new Set(["kept"]));
+    withFiles(
+      { "/work/audio": ["kept.mp3", "orphan.mp3"] },
+      { "kept.mp3": OLD, "orphan.mp3": OLD },
+    );
+
+    await sweepOnce();
+
+    expect(removed()).not.toContain("/work/audio/kept.mp3");
+    expect(removed()).toContain("/work/audio/orphan.mp3");
+  });
+
+  it("still reclaims an orphan that never reached a project", async () => {
+    // `/api/audio` needs no account, so uploads nobody ever used cannot sit on
+    // the disk forever. The TTL is right; it was only ever applied too widely.
+    referencedAudioIds.mockResolvedValue(new Set());
+    withFiles({ "/work/audio": ["nobody.mp3"] }, { "nobody.mp3": OLD });
+
+    await sweepOnce();
+
+    expect(removed()).toContain("/work/audio/nobody.mp3");
+  });
+
+  it("skips the audio sweep entirely when it cannot tell what is referenced", async () => {
+    // The two failure costs are not symmetrical. Skipping leaks disk until the
+    // next pass; deleting anyway destroys a soundtrack nobody can get back. So
+    // a database that is down must never be read as "nothing is referenced".
+    referencedAudioIds.mockRejectedValue(new Error("db down"));
+    withFiles(
+      { "/work/renders": ["a.mp4"], "/work/audio": ["old.mp3"] },
+      { "a.mp4": OLD, "old.mp3": OLD },
+    );
+
+    await sweepOnce();
+
+    expect(removed()).not.toContain("/work/audio/old.mp3");
+    // …and the renders dir, which does not depend on the answer, is untouched
+    // by that decision.
+    expect(removed()).toContain("/work/renders/a.mp4");
   });
 });

--- a/lib/server/audio-file.ts
+++ b/lib/server/audio-file.ts
@@ -1,0 +1,30 @@
+import "server-only";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { AUDIO_EXTS } from "@/lib/video-editor/types";
+import { AUDIO_WORK_DIR } from "./paths";
+
+/**
+ * Is this upload still on disk?
+ *
+ * The id carries no extension — `/api/audio` stores `<uuid>.<ext>` and hands
+ * back only the uuid — so the check probes the handful it could be, the same
+ * way the streaming route does.
+ *
+ * Two callers want this and both used to assume the answer was yes: the export,
+ * which pointed the renderer at a URL that could 404 and shipped a silent video
+ * without saying so, and the editor, which restored a track row for a file that
+ * was gone.
+ */
+export async function audioUploadExists(id: string): Promise<boolean> {
+  const hits = await Promise.all(
+    AUDIO_EXTS.map(async (ext) => {
+      try {
+        return (await stat(path.join(AUDIO_WORK_DIR, `${id}.${ext}`))).isFile();
+      } catch {
+        return false;
+      }
+    }),
+  );
+  return hits.some(Boolean);
+}

--- a/lib/server/audio-refs.ts
+++ b/lib/server/audio-refs.ts
@@ -1,0 +1,44 @@
+import "server-only";
+import { sql } from "drizzle-orm";
+import { videoProjects } from "@/lib/db/schema";
+import { getDb, isDbConfigured } from "@/lib/server/db";
+
+/**
+ * The upload ids that a saved project still points at.
+ *
+ * This exists because two lifetimes were in direct contradiction. A project is
+ * a row in Postgres with no expiry — it is there until its owner deletes it —
+ * and the soundtrack it references was a file on disk with a six-hour TTL. So
+ * every saved project with audio was guaranteed to lose it, and the failure was
+ * silent at both ends: the editor restored the track row from the saved draft
+ * (name, volume, trim and all) with nothing behind it, and the exporter pointed
+ * the renderer at a 404 and shipped a video with no sound.
+ *
+ * The TTL itself is right — `/api/audio` needs no account, so uploads nobody
+ * ever used cannot sit on the disk forever. What was wrong is that it applied
+ * to files something still owned. So the sweep now reclaims *orphans* only.
+ *
+ * With no database configured nothing is persisted server-side at all, so there
+ * is nothing to protect and the TTL stands on its own.
+ *
+ * `-> 'audio' ->> 'uploadId'` is deliberately not guarded by a `jsonb_typeof`
+ * check the way `listProjects` guards `jsonb_array_length`. Verified against
+ * Postgres 14 with rows whose `audio` is an object, `null`, absent entirely,
+ * and a bare string: the arrow operators return NULL for all but the first and
+ * none of them throw, so an old-shaped row cannot take the sweep down — which
+ * matters more here than anywhere, because a sweep that throws is a sweep that
+ * skips, and a sweep that skips forever fills the disk.
+ */
+export async function referencedAudioIds(): Promise<ReadonlySet<string>> {
+  if (!isDbConfigured) return new Set();
+
+  const expr = sql<
+    string | null
+  >`${videoProjects.data} -> 'audio' ->> 'uploadId'`;
+  const rows = await getDb()
+    .select({ id: expr })
+    .from(videoProjects)
+    .where(sql`${expr} is not null`);
+
+  return new Set(rows.map((r) => r.id).filter((id): id is string => !!id));
+}

--- a/lib/server/cleanup.ts
+++ b/lib/server/cleanup.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { readdir, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { AUDIO_EXTS } from "@/lib/video-editor/types";
+import { referencedAudioIds } from "./audio-refs";
 import { AUDIO_WORK_DIR, RENDER_WORK_DIR } from "./paths";
 import { deleteJob } from "./render-queue";
 
@@ -14,11 +15,17 @@ import { deleteJob } from "./render-queue";
  */
 
 /**
- * How long an uploaded soundtrack may sit.
+ * How long an *orphaned* upload may sit — one nothing points at.
  *
  * Much longer than a render's: an MP4 is dead the moment it is downloaded, but
  * audio has to outlive the whole editing session that will eventually reference
  * it — reclaim it early and the export silently comes out with no soundtrack.
+ *
+ * It used to be measured from the upload and nothing ever reset it, so the six
+ * hours ran whether the file was in daily use or had never been touched again.
+ * Two things changed: a file a saved project references is not swept at all
+ * (see {@link referencedAudioIds}), and `/api/audio/[id]` refreshes the mtime
+ * on read, so the clock now measures time since last *use*.
  */
 function audioTtlMs(): number {
   const parsed = Number(process.env.AUDIO_FILE_TTL_MS);
@@ -61,6 +68,7 @@ async function sweepDir(
   ttl: number,
   exts: readonly string[],
   onDelete?: (basename: string) => void,
+  keep?: (basename: string) => boolean,
 ): Promise<void> {
   const now = Date.now();
 
@@ -74,6 +82,7 @@ async function sweepDir(
   await Promise.all(
     entries
       .filter((name) => exts.some((ext) => name.endsWith(`.${ext}`)))
+      .filter((name) => !keep?.(name.replace(/\.[^.]+$/, "")))
       .map(async (name) => {
         const filePath = path.join(dir, name);
         try {
@@ -101,8 +110,34 @@ async function sweepDir(
 export async function sweepOnce(): Promise<void> {
   await Promise.all([
     sweepDir(RENDER_WORK_DIR, ttlMs(), ["mp4"], deleteJob),
-    sweepDir(AUDIO_WORK_DIR, audioTtlMs(), AUDIO_EXTS),
+    sweepAudio(),
   ]);
+}
+
+/**
+ * The audio sweep, which has to know what is still owned before it deletes
+ * anything.
+ *
+ * If the referenced set cannot be read the sweep is **skipped entirely**. The
+ * two failure costs are not symmetrical: skipping leaks disk until the next
+ * pass, deleting anyway destroys a soundtrack somebody cannot get back. Ten
+ * minutes of extra files is the cheaper mistake every time.
+ */
+async function sweepAudio(): Promise<void> {
+  let referenced: ReadonlySet<string>;
+  try {
+    referenced = await referencedAudioIds();
+  } catch (error) {
+    console.warn(
+      "[snapcn] audio sweep skipped — could not read which uploads are still referenced:",
+      error,
+    );
+    return;
+  }
+
+  await sweepDir(AUDIO_WORK_DIR, audioTtlMs(), AUDIO_EXTS, undefined, (id) =>
+    referenced.has(id),
+  );
 }
 
 // Module-level guard: ensure the sweep timer is installed exactly once per

--- a/lib/server/paths.ts
+++ b/lib/server/paths.ts
@@ -50,3 +50,16 @@ if (
     `[snapcn] SHOWCASE_WORK_DIR is unset — approved showcase videos are being written to ${SHOWCASE_WORK_DIR} and will be lost on redeploy. Mount a volume and set SHOWCASE_WORK_DIR (see SHOWCASE_SETUP.md).`,
   );
 }
+
+// The same warning the showcase dir got, for the same reason and one it needed
+// just as badly. A saved project keeps a soundtrack by id forever; if the file
+// is on the container's writable layer it is gone at the next deploy, and the
+// only symptom is a project that opens with a track row and plays silence.
+if (
+  process.env.NODE_ENV === "production" &&
+  AUDIO_WORK_DIR.startsWith(os.tmpdir())
+) {
+  console.warn(
+    `[snapcn] AUDIO_WORK_DIR is unset — uploaded soundtracks are being written to ${AUDIO_WORK_DIR} and will be lost on redeploy, silencing every saved project that references one. Mount a volume and set AUDIO_WORK_DIR (see SHOWCASE_SETUP.md).`,
+  );
+}


### PR DESCRIPTION
A project is a row in Postgres with no expiry — it is there until its owner
deletes it. The soundtrack it references was a file on disk with a six-hour TTL,
measured from the upload and never reset by anything: not saving the project,
not playing it back, not exporting. **Every saved project with audio was
guaranteed to lose it.**

It failed silently at both ends. The editor rebuilds a track's `src` from the
saved draft on reload, so the row came back looking completely normal — name,
volume, trim, the block on the timeline — with a 404 behind it. And
`/api/render` pointed the renderer at that same 404, which fetches it, carries
on, and produces a perfectly good video with no sound that nobody discovers is
wrong until they play it.

## The TTL was not the mistake

`/api/audio` needs no account, so uploads nobody ever used cannot sit on the
disk forever. What was wrong is that it applied to files something still owned.

| | |
| --- | --- |
| `lib/server/audio-refs.ts` | the upload ids a saved project still points at |
| `lib/server/cleanup.ts` | the sweep reclaims **orphans only** |
| `app/api/audio/[id]/route.ts` | reading a track refreshes its mtime — the clock now measures time since last *use* |
| `app/api/render/route.ts` | 409 `audio_missing` instead of exporting silence |
| `components/video-editor/audio-track-row.tsx` | a restored row proves the file exists before rendering a control that would lie |
| `lib/server/paths.ts` | boot warning if `AUDIO_WORK_DIR` is not on a volume |

Two decisions worth reviewing rather than skimming:

- **If the referenced-ids read fails, the audio sweep is skipped entirely** — it
  does not fall back to the TTL. The costs are not symmetrical: skipping leaks
  disk until the next pass, deleting anyway destroys a file nobody can get back.
  A database that is down must never be read as "nothing is referenced".
- **The mtime refresh is gated on age.** Chrome issues a range request per seek
  while it decodes audio, so touching unconditionally would be a metadata write
  per seek. The stat is already in hand, so the common case costs one comparison
  and no syscall.

## Verified against a real database

Postgres 14, real files on disk, the real `sweepOnce()`, no mocks — every file
twelve hours old against a six-hour TTL:

| scenario | result |
| --- | --- |
| a saved project references it | **survives** |
| nothing references it | reclaimed |
| the project is then deleted | reclaimed |
| database unreachable | **survives** |

The query was checked against rows whose `data.audio` is an object, `null`,
absent entirely, and a bare **string**, plus the same upload id shared by two
projects. It returns one deduped id and none of the malformed shapes throw —
which matters here more than anywhere, because `listProjects` already has to
guard `jsonb_array_length` for exactly that reason, and a sweep that throws is a
sweep that skips.

Three unit tests cover the sweep's orphan-only behaviour and the skip-on-failure
path; removing the keep-predicate fails the first one.

## Checks

- `pnpm test` — 887 passing
- `pnpm run build` — clean
- biome clean on all eight files

## Not covered

Nobody has driven this end to end through the browser — saving a project needs
an authenticated session, so the query, the sweep and the export guard were each
proven separately rather than in one continuous click-through.

Independent of #16: no file overlap, so the two can land in either order.
