### PR TITLE
Stop losing installs at the two places we could not see

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -5,6 +5,7 @@ import {
   captureServer,
   distinctIdFromCookie,
 } from "@/lib/analytics-server";
+import { recordSearch } from "@/lib/server/search-log";
 import { source } from "@/source";
 
 /**
@@ -25,6 +26,15 @@ import { source } from "@/source";
  * highest-signal input to what gets built next, and it is invisible in every
  * other event on the site — they search, find nothing, and leave without
  * clicking anything we could have measured.
+ *
+ * ## Why the query is not sent from here
+ *
+ * Because a request per keystroke means an event per keystroke, and the first
+ * thirty days of this collected thirteen events describing five searches — four
+ * of them prefixes of `combobox`. The length guard below removes two characters
+ * of that and no more. {@link recordSearch} holds each query until the person
+ * stops typing and emits only what they settled on; see the note there for why
+ * the rule is last-write-wins rather than longest-prefix.
  */
 const { GET: search } = createFromSource(source);
 
@@ -33,8 +43,8 @@ export async function GET(request: Request) {
 
   const query = new URL(request.url).searchParams.get("query")?.trim();
   // Fumadocs fires a request per keystroke. One- and two-character queries are
-  // that debounce leaking through, not intent, and logging them would bury the
-  // real ones.
+  // never intent, so they are dropped before they can even take a slot in the
+  // buffer; everything longer is debounced by `recordSearch`.
   if (query && query.length >= 3) {
     // `clone()`: the body can only be read once, and the caller needs it.
     const results = await response
@@ -52,12 +62,27 @@ export async function GET(request: Request) {
             "unknown",
           ua ?? "none",
         ));
-      await captureServer("docs_searched", distinctId, {
+      // Returns the *earlier* searches this one has settled, never itself.
+      const settled = recordSearch({
+        distinctId,
         query: query.toLowerCase(),
         results,
-        // The property to build the "what are we missing" insight on.
-        zero_results: results === 0,
+        at: Date.now(),
       });
+
+      for (const s of settled) {
+        await captureServer(
+          "docs_searched",
+          s.distinctId,
+          {
+            query: s.query,
+            results: s.results,
+            // The property to build the "what are we missing" insight on.
+            zero_results: s.results === 0,
+          },
+          new Date(s.at).toISOString(),
+        );
+      }
     });
   }
 

--- a/components/docs/install-block.tsx
+++ b/components/docs/install-block.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { installCommand } from "@/config/site";
 import { convertNpmCommand } from "@/lib/convert-npm-command";
 import { CodeBlockCommand } from "./code-block-command";
@@ -9,6 +10,20 @@ import { CodeBlockCommand } from "./code-block-command";
  * Both `registry/*` items publish to the same flat `/r/<name>.json`, so the
  * `registry` prop no longer picks a path — it only names the component for the
  * agent prompt.
+ *
+ * ## Why the prerequisite line is here and not only on the install page
+ *
+ * A component page is a *landing* page. Every one of them is in the sitemap
+ * aimed at a search like "remotion karaoke captions", so the first thing a
+ * stranger ever sees of snapcn is this command — and running it in a bare
+ * Remotion project fails with `We could not detect a supported framework`,
+ * because `shadcn init` does not recognise Remotion and there is no
+ * `components.json` for it to read.
+ *
+ * That is not a hypothesis. It is what happens, it is two steps to avoid, and
+ * the page that explains it was reachable only by someone who already knew to
+ * look for it. One muted line costs a returning reader nothing and saves a new
+ * one the only failure this project reliably produces.
  */
 export function InstallBlock({
   name,
@@ -26,6 +41,16 @@ export function InstallBlock({
         prompt={`Add the ${registry} ${name} component to my project by running: ${npmCommand}`}
         {...convertNpmCommand(npmCommand)}
       />
+      <p className="mt-2 text-muted-foreground text-xs">
+        Needs an existing Remotion project and a <code>components.json</code>.{" "}
+        <Link
+          href="/docs/getting-started/installation"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          Two-minute setup
+        </Link>{" "}
+        if this is your first snapcn component.
+      </p>
     </div>
   );
 }

--- a/components/video-editor/editor-player.tsx
+++ b/components/video-editor/editor-player.tsx
@@ -43,6 +43,7 @@ export function EditorPlayer({
   font,
   playerRef,
   onFrame,
+  onPlay: onPlayed,
 }: {
   clips: Clip[];
   /** Preview only — the exported file's mark is decided by the server. */
@@ -52,6 +53,8 @@ export function EditorPlayer({
   font: string;
   playerRef: React.RefObject<EditorPlayerHandle | null>;
   onFrame: (frame: number) => void;
+  /** Fired the first time playback starts — see `editor_abandoned`. */
+  onPlay?: () => void;
 }) {
   const [player, setPlayer] = useState<PlayerRef | null>(null);
   const [playing, setPlaying] = useState(false);
@@ -79,7 +82,10 @@ export function EditorPlayer({
   // effect is null on the pass that matters. State forces the re-subscribe.
   useEffect(() => {
     if (!player) return;
-    const onPlay = () => setPlaying(true);
+    const onPlay = () => {
+      setPlaying(true);
+      onPlayed?.();
+    };
     const onPause = () => setPlaying(false);
     const onFrameUpdate = (e: { detail: { frame: number } }) => {
       setFrame(e.detail.frame);

--- a/components/video-editor/video-editor.tsx
+++ b/components/video-editor/video-editor.tsx
@@ -90,6 +90,40 @@ export function VideoEditor({
   }, [trackEvent]);
 
   /**
+   * What the timeline looked like when somebody gave up on it.
+   *
+   * Read through refs rather than state: this fires from a `pagehide` listener
+   * that is registered once, and a listener registered once closes over the
+   * state of the first render forever. The refs are written on every render, so
+   * the handler always sees the timeline as it actually was.
+   */
+  const shape = useRef({ clips: 0, previewed: false, audio: false });
+  shape.current.clips = clips.length;
+  shape.current.audio = Boolean(audio);
+  const openedAt = useRef(Date.now());
+  const exported = useRef(false);
+  // Set the moment a render is requested, not when it finishes: somebody who
+  // pressed export and closed the tab while it ran has not abandoned anything.
+  if (exporting) exported.current = true;
+
+  useEffect(() => {
+    const onLeave = () => {
+      // Leaving after you got the file is not abandonment.
+      if (exported.current) return;
+      trackEvent("editor_abandoned", {
+        clip_count: shape.current.clips,
+        previewed: shape.current.previewed,
+        had_audio: shape.current.audio,
+        seconds: Math.round((Date.now() - openedAt.current) / 1000),
+      });
+    };
+    // `pagehide`, not `beforeunload`: the latter never fires on a discarded
+    // mobile tab, which is exactly where a half-built video gets abandoned.
+    window.addEventListener("pagehide", onLeave);
+    return () => window.removeEventListener("pagehide", onLeave);
+  }, [trackEvent]);
+
+  /**
    * Load a stored timeline into the editor. `null` empties it — a new video.
    *
    * Stable, and it must stay that way: `useProjects` restores through this on
@@ -383,6 +417,9 @@ export function VideoEditor({
             font={font}
             playerRef={playerRef}
             onFrame={setCurrentFrame}
+            onPlay={() => {
+              shape.current.previewed = true;
+            }}
           />
         </div>
 

--- a/lib/__tests__/registry-suggest.test.ts
+++ b/lib/__tests__/registry-suggest.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { INSTALL_ALL_NAMES } from "@/config/site";
+import { suggestComponents } from "@/lib/registry-suggest";
+
+const suggest = (q: string) => suggestComponents(q, INSTALL_ALL_NAMES);
+
+describe("suggestComponents", () => {
+  it("says nothing for the names that were actually invented", () => {
+    // Verbatim from thirty days of `registry_component_missing`. None of these
+    // is a typo of anything we ship, and offering the least-bad name in the
+    // registry would send someone to install the wrong component confidently.
+    for (const invented of [
+      "blur-out-up",
+      "dynamic-grid",
+      "soft-blur-in",
+      "number-wheel",
+      "shader-warp",
+      "line-by-line-slide",
+      "frosted-glass-wipe",
+      "rgb-glitch-text",
+      "button",
+      "dropdown",
+      "combobox",
+    ]) {
+      expect(suggest(invented), invented).toEqual([]);
+    }
+  });
+
+  it("catches a typo of a real name", () => {
+    expect(suggest("text-revel")).toContain("text-reveal");
+    expect(suggest("prompt-sned")).toContain("prompt-send");
+    expect(suggest("logo-driftt")).toContain("logo-drift");
+  });
+
+  it("catches a near-miss on wording", () => {
+    // Half the hyphenated words shared is the bar.
+    expect(suggest("text-reveal-words")).toContain("text-reveal");
+    expect(suggest("laptop-frame-scroll")).toContain("laptop-frame");
+  });
+
+  it("returns an exact name unchanged, if one is ever asked for", () => {
+    expect(suggest("text-select")[0]).toBe("text-select");
+  });
+
+  it("offers at most three, best first", () => {
+    expect(suggest("text-").length).toBeLessThanOrEqual(3);
+  });
+
+  it("is not confused by an empty or absurd name", () => {
+    expect(suggest("")).toEqual([]);
+    expect(suggest("-".repeat(200))).toEqual([]);
+  });
+});
+
+describe("llms.txt names every installable component", () => {
+  it("lists all of them, so an agent never has to guess", async () => {
+    const { LLMS_HEADER } = await import("@/lib/llms");
+    for (const name of INSTALL_ALL_NAMES) {
+      expect(LLMS_HEADER, name).toContain(`@snapcn/${name}\``);
+    }
+  });
+
+  it("tells the agent the list is closed", async () => {
+    const { LLMS_HEADER } = await import("@/lib/llms");
+    expect(LLMS_HEADER).toMatch(/complete set/i);
+    expect(LLMS_HEADER).toMatch(/do not\s+infer, pluralise or invent/i);
+  });
+});

--- a/lib/analytics-server.ts
+++ b/lib/analytics-server.ts
@@ -113,6 +113,16 @@ export async function captureServer(
   event: ServerEvent,
   distinctId: string,
   properties: Props = {},
+  /**
+   * When the thing happened, if that is not now.
+   *
+   * Only the debounced docs search passes this: it holds a query until the
+   * person stops typing, so the flush can be seconds — or, if nobody searches
+   * again, much longer — after the search itself. Without this the event would
+   * land at flush time and a search made last thing at night could be counted
+   * against the next morning.
+   */
+  timestamp: string = new Date().toISOString(),
 ): Promise<void> {
   // Same dev gate as the client provider: a local `pnpm dev` hitting
   // /r/<thing>.json must not land in the install count that decides what gets
@@ -133,7 +143,7 @@ export async function captureServer(
           // event, don't mint a person for every crawler that hits the registry.
           $process_person_profile: false,
         },
-        timestamp: new Date().toISOString(),
+        timestamp,
       }),
     });
   } catch {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -92,6 +92,30 @@ type AnalyticsEvents = {
     component: string;
     clip_count: number;
   };
+  /**
+   * The editor being left, and what was on the timeline when it was.
+   *
+   * The funnel said 54 people opened the editor, 30 added a clip and 7
+   * exported — so 23 built something and walked away, and nothing on the site
+   * could say whether they were tyre-kicking or blocked. This is what tells
+   * those apart: one clip and forty seconds is a look around, five clips and
+   * eight minutes with the preview played twice is somebody who wanted a video
+   * and did not get one.
+   *
+   * Fired on `pagehide`, which — unlike `beforeunload` — is reliable on mobile
+   * and on tab discard. Exports are excluded: leaving after you got what you
+   * came for is not abandonment.
+   */
+  editor_abandoned: {
+    /** How much was on the timeline at the end. */
+    clip_count: number;
+    /** Whether they ever pressed play — an editor nobody previews is not read. */
+    previewed: boolean;
+    /** Whether a soundtrack was added, which is a strong intent signal. */
+    had_audio: boolean;
+    /** Wall-clock in the editor. Forty seconds and eight minutes mean different things. */
+    seconds: number;
+  };
   editor_export_started: {
     clip_count: number;
   };

--- a/lib/llms.ts
+++ b/lib/llms.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { DOCS_PAGE_META } from "@/config/site";
+import { DOCS_PAGE_META, INSTALL_ALL_NAMES } from "@/config/site";
 import { CANVAS, MAX_CLIPS, MAX_TOTAL_FRAMES } from "@/lib/video-editor/types";
 import {
   GALLERY_CATEGORIES,
@@ -240,6 +240,36 @@ function lastUpdated(): string {
   return dates.sort().at(-1) ?? "";
 }
 
+/**
+ * Every name `@snapcn/<name>` resolves to, and a flat statement that there are
+ * no others.
+ *
+ * This exists because of what happened without it. `llms.txt` told an agent the
+ * install pattern was `@snapcn/<component>` and then never named a single
+ * component — the gallery section lists *display* names behind links, so the
+ * slug had to be guessed. Agents guessed. In thirty days the registry served
+ * **208 requests for names that do not exist** across 41 distinct spellings —
+ * `blur-out-up` (21), `dynamic-grid` (10), `soft-blur-in` (9), `number-wheel`,
+ * `line-by-line-slide`, `shader-warp` — none of which appear anywhere in this
+ * repository, in the roadmap, or in any link. They were invented, and every one
+ * was a person who typed `npx shadcn add` and got a 404. That is one failed
+ * install for every eight that worked, landing on the most committed user we
+ * have.
+ *
+ * So the list is exhaustive, it says so, and it is generated from the same
+ * `INSTALL_ALL_NAMES` the install-everything button uses — which is built from
+ * both registry manifests. A new component appears here by existing.
+ */
+const INSTALLABLE = `## Every installable component
+
+These ${INSTALL_ALL_NAMES.length} names are the complete set. \`@snapcn/<name>\`
+resolves for these and for nothing else — any other name returns 404, so do not
+infer, pluralise or invent one. If what you want is not on this list, snapcn does
+not have it yet; say so rather than guessing a plausible name.
+
+${INSTALL_ALL_NAMES.map((name) => `- \`npx shadcn@latest add @snapcn/${name}\``).join("\n")}
+`;
+
 export const LLMS_HEADER = `# snapcn
 
 > snapcn is a shadcn-style registry of ${GALLERY_ITEMS.length} production-ready video components for Remotion (React). Developers install components with \`npx shadcn@latest add @snapcn/<component>\`; the source and everything it depends on is copied into their project and they own the code. Typical use: building product demo videos, launch videos and social clips in React.
@@ -250,4 +280,5 @@ Prerequisites: an existing Remotion project (\`npx create-video@latest\`) and th
 
 Maintained by Sri Nath. Project account: https://x.com/snapcndev
 Last updated: ${lastUpdated()} (newest component release)
-`;
+
+${INSTALLABLE}`;

--- a/lib/registry-suggest.ts
+++ b/lib/registry-suggest.ts
@@ -1,0 +1,78 @@
+/**
+ * "Did you mean…" for a registry name that does not exist.
+ *
+ * Deliberately conservative. Most of what gets requested has no near match at
+ * all — thirty days of misses included `blur-out-up`, `dynamic-grid`,
+ * `shader-warp` and `number-wheel`, and the honest answer to every one of them
+ * is "snapcn does not have that", not the least-bad name in the registry. A
+ * confident wrong suggestion is worse than none: it sends someone to install a
+ * component that does not do what they asked for.
+ *
+ * Two ways to qualify, because the misses come from two different mistakes:
+ *
+ *  - **A typo** — `text-revel`, `promt-send`. Caught by edit distance ≤ 2.
+ *  - **A near-miss on wording** — `text-swap-words`, `reveal-text`. Caught by
+ *    sharing at least half the hyphen-separated words.
+ *
+ * An invented name passes neither, which is the point.
+ */
+
+/** Edit distance, capped — anything past `max` is "far" and the value is unused. */
+function editDistance(a: string, b: string, max = 3): number {
+  if (Math.abs(a.length - b.length) > max) return max + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    let best = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      row[j] = Math.min(
+        (prev[j] as number) + 1,
+        (row[j - 1] as number) + 1,
+        (prev[j - 1] as number) + cost,
+      );
+      best = Math.min(best, row[j] as number);
+    }
+    // Whole remaining rows can only grow, so a row that is already too far ends it.
+    if (best > max) return max + 1;
+    prev = row;
+  }
+  return prev[b.length] as number;
+}
+
+/** Fraction of hyphen-separated words the two names share. */
+function wordOverlap(a: string, b: string): number {
+  const wa = new Set(a.split("-").filter(Boolean));
+  const wb = new Set(b.split("-").filter(Boolean));
+  if (!wa.size || !wb.size) return 0;
+  let shared = 0;
+  for (const w of wa) if (wb.has(w)) shared++;
+  return shared / Math.max(wa.size, wb.size);
+}
+
+/**
+ * The closest real names to `wanted`, best first — usually none.
+ *
+ * @param limit how many to offer; three is enough to be useful and few enough
+ *              to read in a terminal.
+ */
+export function suggestComponents(
+  wanted: string,
+  known: readonly string[],
+  limit = 3,
+): string[] {
+  const name = wanted.toLowerCase();
+  return known
+    .map((candidate) => {
+      const distance = editDistance(name, candidate);
+      const overlap = wordOverlap(name, candidate);
+      // Rank by overlap first — a shared word means more than a shared letter —
+      // and fall back to closeness for the pure-typo case.
+      const score = overlap * 10 + (distance <= 2 ? 3 - distance : 0);
+      return { candidate, score, distance, overlap };
+    })
+    .filter((c) => c.distance <= 2 || c.overlap >= 0.5)
+    .sort((a, b) => b.score - a.score || a.candidate.localeCompare(b.candidate))
+    .slice(0, limit)
+    .map((c) => c.candidate);
+}

--- a/lib/server/__tests__/search-log.test.ts
+++ b/lib/server/__tests__/search-log.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetSearchLog,
+  flushSettled,
+  IDLE_MS,
+  recordSearch,
+} from "@/lib/server/search-log";
+
+const T0 = 1_800_000_000_000;
+const type = (query: string, at: number, distinctId = "p1", results = 0) =>
+  recordSearch({ distinctId, query, results, at }, at).map((s) => s.query);
+
+beforeEach(__resetSearchLog);
+
+describe("search-log", () => {
+  it("collapses the burst that was actually logged", () => {
+    // Verbatim from thirty days of production: four events for one search.
+    let emitted: string[] = [];
+    ["combo", "combob", "comboboc", "combobox"].forEach((q, i) => {
+      emitted = emitted.concat(type(q, T0 + i * 180));
+    });
+    expect(emitted).toEqual([]); // nothing while they are still typing
+    expect(flushSettled(T0 + 5_000).map((s) => s.query)).toEqual(["combobox"]);
+  });
+
+  it("keeps a correction, which is not a prefix", () => {
+    // `comboboc` → `combobox` diverges at the last character. Longest-prefix
+    // matching would have emitted both; last-write-wins emits one.
+    type("comboboc", T0);
+    type("combobox", T0 + 150);
+    expect(flushSettled(T0 + 5_000).map((s) => s.query)).toEqual(["combobox"]);
+  });
+
+  it("does not merge two deliberate searches", () => {
+    type("dropdown", T0);
+    const settled = type("combobox", T0 + IDLE_MS + 1);
+    expect(settled).toEqual(["dropdown"]); // the first went out on its own
+    expect(flushSettled(T0 + 99_999).map((s) => s.query)).toEqual(["combobox"]);
+  });
+
+  it("never emits the search it was just handed", () => {
+    expect(type("dropdown", T0)).toEqual([]);
+  });
+
+  it("keeps people apart", () => {
+    type("dropdown", T0, "p1");
+    type("waveform", T0 + 10, "p2");
+    expect(
+      flushSettled(T0 + 5_000)
+        .map((s) => s.query)
+        .sort(),
+    ).toEqual(["dropdown", "waveform"]);
+  });
+
+  it("emits the time of the search, not of the flush", () => {
+    // A query held overnight must still count against the day it was typed.
+    type("confetti", T0);
+    const [out] = flushSettled(T0 + 12 * 60 * 60_000);
+    expect(out?.at).toBe(T0);
+  });
+
+  it("carries the result count through, so zero_results survives", () => {
+    recordSearch(
+      { distinctId: "p1", query: "ken burns", results: 0, at: T0 },
+      T0,
+    );
+    const [out] = flushSettled(T0 + 5_000);
+    expect(out).toMatchObject({ query: "ken burns", results: 0 });
+  });
+});

--- a/lib/server/search-log.ts
+++ b/lib/server/search-log.ts
@@ -1,0 +1,113 @@
+import "server-only";
+
+/**
+ * Collapses a burst of search-as-you-type requests into the one query the
+ * person actually stopped on.
+ *
+ * ## The bug
+ *
+ * fumadocs fires a request per keystroke, so one search arrived as one event
+ * per character. Thirty days of real data was thirteen events describing five
+ * searches:
+ *
+ *     combo · combob · comboboc · combobox
+ *     dropd · dropdo · dropdown · dropdown'
+ *     mai · mais        syna · synam        prest
+ *
+ * The route already dropped queries under three characters, which removes the
+ * first two keystrokes and nothing else. Every prefix from three up still
+ * landed, and each one counted as its own zero-result "component request" —
+ * so the signal the route exists to collect said "people want `combo`" four
+ * times and "people want `combobox`" once.
+ *
+ * ## The rule
+ *
+ * A search replaces the one that person made moments ago; only what survives
+ * {@link IDLE_MS} of quiet is emitted. Last-write-wins rather than
+ * longest-prefix-wins, because a correction is not a prefix — `comboboc` →
+ * `combobox` diverges at the final character, and prefix matching would have
+ * emitted both.
+ *
+ * Merging two deliberate searches made inside the window is the failure mode
+ * this accepts. It is the right way round: emitting a half-typed word is the
+ * bug being fixed, and losing the first of two rapid searches costs one data
+ * point of the same kind.
+ *
+ * ## Why it survives being deployed
+ *
+ * The buffer is in-process, which is exact on the single container this runs on
+ * and degrades to today's behaviour if it were ever spread across instances —
+ * some prefixes leak through, nothing breaks.
+ *
+ * Flushing is driven two ways on purpose. `sweep` runs on every incoming
+ * search, so the buffer drains without needing a live timer; the caller may
+ * also arm one for timeliness. Neither is required for correctness, because an
+ * emitted event carries the timestamp of the *search*, not of the flush — a
+ * query that sits in the buffer overnight still lands on the right day.
+ */
+
+/** How long a person must stop typing before their query counts as intent. */
+export const IDLE_MS = 2500;
+
+/** A ceiling so a flood cannot grow the buffer without bound. */
+const MAX_PENDING = 500;
+
+export interface PendingSearch {
+  distinctId: string;
+  query: string;
+  results: number;
+  /** When the search happened — not when it was flushed. */
+  at: number;
+}
+
+const pending = new Map<string, PendingSearch>();
+
+/** Everything that has gone quiet, oldest first. Removes what it returns. */
+function sweep(now: number): PendingSearch[] {
+  const out: PendingSearch[] = [];
+  for (const [id, p] of pending) {
+    if (now - p.at >= IDLE_MS) {
+      out.push(p);
+      pending.delete(id);
+    }
+  }
+  return out.sort((a, b) => a.at - b.at);
+}
+
+/**
+ * Record a search. Returns the searches that are now settled and should be
+ * sent — which is usually nothing, and never the one just passed in.
+ */
+export function recordSearch(
+  search: PendingSearch,
+  now: number = Date.now(),
+): PendingSearch[] {
+  // Sweep first: if this person's previous query has already gone quiet it is a
+  // separate search, not a keystroke, and it goes out rather than being
+  // overwritten by this one.
+  const settled = sweep(now);
+
+  pending.set(search.distinctId, { ...search, at: now });
+
+  // Oldest out first if the buffer is somehow full. Cannot happen at this
+  // traffic; it is here so it cannot happen at any traffic.
+  while (pending.size > MAX_PENDING) {
+    const oldest = [...pending.values()].reduce((a, b) =>
+      b.at < a.at ? b : a,
+    );
+    pending.delete(oldest.distinctId);
+    settled.push(oldest);
+  }
+
+  return settled;
+}
+
+/** Drain everything quiet right now. For a timer, or a shutdown. */
+export function flushSettled(now: number = Date.now()): PendingSearch[] {
+  return sweep(now);
+}
+
+/** Test seam — the buffer is module state and each test needs its own. */
+export function __resetSearchLog(): void {
+  pending.clear();
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,7 @@ import {
   classifyClient,
   distinctIdFromCookie,
 } from "@/lib/analytics-server";
+import { suggestComponents } from "@/lib/registry-suggest";
 
 /**
  * Every component that actually exists, from the same manifests the registry is
@@ -67,8 +68,15 @@ function componentFromPath(pathname: string): string | null {
 }
 
 export async function middleware(request: NextRequest) {
-  const response = NextResponse.next();
   const { pathname } = request.nextUrl;
+  const requested = componentFromPath(pathname);
+  // Answer the miss here rather than letting it fall through to the HTML 404.
+  // The analytics below still runs either way — `after()` is attached to
+  // whichever response we return.
+  const response =
+    requested && !KNOWN_COMPONENTS.has(requested)
+      ? unknownComponent(requested, request.nextUrl.origin)
+      : NextResponse.next();
 
   after(async () => {
     const ua = request.headers.get("user-agent");
@@ -113,6 +121,52 @@ export async function middleware(request: NextRequest) {
   });
 
   return response;
+}
+
+/**
+ * What a request for a component we do not have gets back.
+ *
+ * It used to get the site's HTML 404 — twenty-seven kilobytes of React shell
+ * sent to a terminal, saying nothing a CLI or an agent could act on. That is
+ * the wrong answer to what turned out to be a common question: thirty days of
+ * traffic contained **208 requests for names that do not exist**, one for every
+ * eight that worked, and they arrive from the most committed person in the
+ * funnel — someone who has already typed `npx shadcn add`.
+ *
+ * So it answers in the language it was asked in. JSON, a few hundred bytes, and
+ * the two things the caller actually needs: that the name is wrong, and where
+ * the real ones are. `suggestComponents` offers alternatives only when it has a
+ * genuine one; most invented names get none, which is the truthful reply.
+ *
+ * The agents inventing these names read response bodies, and this is the only
+ * place we can talk to them at the moment it matters.
+ *
+ * `origin` comes off the request rather than a constant so a preview deployment
+ * points at itself — and so this file imports nothing that would drag `node:fs`
+ * into the Edge bundle.
+ */
+function unknownComponent(component: string, origin: string): NextResponse {
+  const suggestions = suggestComponents(component, INSTALL_ALL_NAMES);
+  return NextResponse.json(
+    {
+      error: `\`@snapcn/${component}\` does not exist.`,
+      component,
+      suggestions,
+      message: suggestions.length
+        ? `Did you mean ${suggestions.map((s) => `@snapcn/${s}`).join(", ")}?`
+        : `snapcn has no component by that name. It has ${INSTALL_ALL_NAMES.length}; do not guess another spelling.`,
+      components: INSTALL_ALL_NAMES,
+      docs: `${origin}/docs/components`,
+      llms: `${origin}/llms.txt`,
+    },
+    {
+      status: 404,
+      headers: {
+        // Wrong names are stable and get retried; let the edge absorb them.
+        "cache-control": "public, max-age=300, s-maxage=3600",
+      },
+    },
+  );
 }
 
 export const config = {


### PR DESCRIPTION
Four changes from reading a month of PostHog. Two are losses happening right
now; two are instruments for questions the site cannot currently answer.

## 208 failed installs a month, and llms.txt was the cause

Thirty days of registry traffic contained **208 requests for components that do
not exist** — one failed install for every eight that worked, arriving from the
most committed person in the funnel: someone who has already typed
`npx shadcn add`.

They were not typos. `blur-out-up` (21), `dynamic-grid` (10), `soft-blur-in`
(9), `number-wheel`, `line-by-line-slide`, `shader-warp` — **41 distinct names,
none of which appears anywhere in this repository**, in the roadmap, or in any
link. They were invented, and `llms.txt` is why: it told a reader the install
pattern was `@snapcn/<component>` and then never named a single component. The
gallery section lists *display* names behind links, so the slug had to be
guessed, and `llms_txt_fetched` says 44 agents a month were guessing.

- `llms.txt` now names all 32, states the list is complete, and says not to
  infer, pluralise or invent one. Generated from `INSTALL_ALL_NAMES`, so a new
  component appears there by existing.
- A miss answers in the language it was asked in: **758 bytes of JSON** instead
  of 27KB of React shell sent to a terminal.

`suggestComponents` is deliberately quiet — tested against the eleven names
actually requested, it offers **nothing** for every one. A confident wrong
suggestion sends somebody to install a component that does not do what they
asked. It speaks only for a typo or a real near-miss on wording.

| request | before | after |
| --- | --- | --- |
| `blur-out-up` | 27KB HTML | 404 JSON, no suggestion |
| `text-revel` | 27KB HTML | "Did you mean `@snapcn/text-reveal`?" |
| `text-select` | 200 | 200 |

## Search logged a keystroke, not a search

Thirteen events described five searches: `combo · combob · comboboc · combobox`,
`dropd · dropdo · dropdown · dropdown'`. The existing three-character guard
removes two keystrokes and nothing else, so every prefix counted as its own
zero-result "component request".

Now debounced per person. **Last-write-wins rather than longest-prefix**, because
a correction is not a prefix — `comboboc` → `combobox` diverges at the final
character and prefix matching would have emitted both. Merging two deliberate
searches inside the window is the accepted failure mode, and it is the right way
round.

`captureServer` gains an optional timestamp so a held query lands on the day it
was typed, not the day it flushed.

## The editor's 31 → 7 drop is now explainable

54 opened the editor, 30 added a clip, 7 exported. There is **no gate** between
those last two — only a zero-clip guard — so the drop is behavioural and no
existing event describes it.

`editor_abandoned` carries the timeline's shape at the end: clips, whether the
preview was played, whether audio was added, seconds spent. *One clip and forty
seconds* is a look around; *five clips and eight minutes* is somebody who wanted
a video and did not get one. Those need opposite fixes and currently look
identical.

Reads through refs (a listener registered once closes over first-render state
forever) and fires on `pagehide`, since `beforeunload` never fires on a
discarded mobile tab — which is exactly where a half-built video dies.

## The install command now says what it needs

Every component page is a landing page aimed at a search. A stranger's first
sight of snapcn is the command, and running it in a bare Remotion project fails
with `We could not detect a supported framework`. Observed first-hand. One muted
line under the command.

## Not in here

- **The customizer stays.** It looked like dead weight at 4 users until measured
  against its real denominator: 4 of the 22 people who reach a component page,
  which is **18% engagement**.
- **Browser ↔ terminal attribution is not solved.** `anonymousId` hashes IP *and*
  user-agent, so the two never match; closing it needs sign-in or an official
  CLI, not more plumbing.

## Checks

- `pnpm test` — 902 passing
- `pnpm run build` — clean, Edge bundle included
- Verified against a running server: 404 body, typo suggestion, real component
  still 200
