### PR TITLE
Put the price where the watermark is

### DIFF
--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -93,9 +93,9 @@ export default async function SignInPage({
               Sign in to snapcn
             </h1>
             <p className="mt-1.5 mb-5 text-sm text-muted-foreground">
-              Removes the watermark from video-editor exports and lets you post
-              to the showcase. The components stay MIT either way, and a local
-              render is never marked.
+              Saves your projects and lets you post to the showcase. Removing
+              the watermark from an export is Starter, $19/mo. The components
+              stay MIT either way, and a local render is never marked.
             </p>
 
             {error && (

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -136,9 +136,9 @@ function SignInDialog({ className }: { className?: string }) {
         <DialogHeader>
           <DialogTitle>Sign in to snapcn</DialogTitle>
           <DialogDescription>
-            Removes the watermark from video-editor exports and lets you post to
-            the showcase. Nothing else changes — the components stay MIT and a
-            local render is never marked.
+            Saves your projects and lets you post to the showcase. Removing the
+            watermark from an export is Starter, $19/mo — the components stay
+            MIT either way, and a local render is never marked.
           </DialogDescription>
         </DialogHeader>
 

--- a/components/video-editor/watermark-badge.tsx
+++ b/components/video-editor/watermark-badge.tsx
@@ -15,19 +15,29 @@ import type { AuthProviderId } from "@/lib/auth-providers";
 import { startCheckout } from "@/lib/upgrade";
 
 /**
+ * Written once. The signed-out pill and the signed-in one are the same offer,
+ * and a price that changes as someone signs in reads as a bait price.
+ */
+const STARTER_PRICE = "$19";
+const REMOVE_LABEL = `Watermark — remove for ${STARTER_PRICE}/mo`;
+
+/**
  * Says what the export will contain, and offers the one thing that changes it.
  *
- * Deliberately states the *current* fact ("Watermarked") rather than nagging
- * ("Remove the watermark!"): the reader is mid-task, and a status they can act
- * on reads better than a demand. Signed in, it stops being a control at all
- * and becomes a quiet confirmation — nobody needs a button for a thing that is
- * already true.
+ * Deliberately states the *current* fact rather than nagging: the reader is
+ * mid-task, and a status they can act on reads better than a demand. What the
+ * status is worth saying alongside is the price, in every state where the mark
+ * is still on — this badge is the only place in the editor the paid tier is
+ * ever mentioned, so a reader who never opens the pricing page learns here or
+ * nowhere. Signed out it used to offer sign-in and claim that removed the mark;
+ * since Starter exists that was simply false, and the funnel ended in a free
+ * account that still exported marked.
  *
  * The mark is not a nag either. A local `npx remotion render` of the same
  * component is unmarked forever, because the source is MIT and the reader owns
- * it; what this asks payment-in-signup for is *our* CPU. The copy says so,
- * because a limit whose reason is stated reads as fair and one that is not
- * reads as crippleware.
+ * it; what this charges for is *our* CPU. The copy says so, because a limit
+ * whose reason is stated reads as fair and one that is not reads as
+ * crippleware.
  */
 export function WatermarkBadge({
   signedIn,
@@ -85,7 +95,7 @@ export function WatermarkBadge({
           <Sparkles className="size-3" />
         )}
         <span className="hidden sm:inline">
-          {starting ? "Opening checkout…" : "Watermark — remove for $19/mo"}
+          {starting ? "Opening checkout…" : REMOVE_LABEL}
         </span>
         <span className="sm:hidden">Mark</span>
       </button>
@@ -118,18 +128,20 @@ export function WatermarkBadge({
         if (open) trackEvent("sign_in_opened", { surface: "editor_watermark" });
       }}
     >
-      <PopoverTrigger className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground">
-        <Sparkles className="size-3.5" />
-        Watermarked
+      <PopoverTrigger className="inline-flex items-center gap-1.5 rounded-full bg-muted py-1 pr-2.5 pl-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground sm:pr-3">
+        <Sparkles className="size-3" />
+        <span className="hidden sm:inline">{REMOVE_LABEL}</span>
+        <span className="sm:hidden">Mark</span>
       </PopoverTrigger>
 
       <PopoverContent align="end" className="w-80">
         <p className="text-sm font-medium text-foreground">
-          Sign in for a clean export
+          Remove the watermark — {STARTER_PRICE}/mo
         </p>
         <p className="mt-1.5 text-sm text-muted-foreground">
           Rendering an MP4 runs Chromium on our machines, so the free export
-          carries a small snapcn mark. Signing in removes it.
+          carries a small snapcn mark at 720p. Starter drops the mark and
+          renders at 1080p.
         </p>
         <p className="mt-2 text-sm text-muted-foreground">
           Rendering the same components locally with{" "}
@@ -137,6 +149,11 @@ export function WatermarkBadge({
             npx remotion render
           </code>{" "}
           is never watermarked — that code is yours.
+        </p>
+
+        <p className="mt-3 text-sm text-muted-foreground">
+          Checkout attaches the plan to whoever paid, so it starts with an
+          account. The price is on this badge again once you are back.
         </p>
 
         <div className="mt-4">


### PR DESCRIPTION
The editor never told anyone the watermark could be bought off.

Signed out — every first visit — the badge read **"Watermarked"** and its popover said *"Sign in for a clean export… Signing in removes it."* True before Starter existed, false since: signing in gets the free plan, which still exports marked at 720p. The $19 button existed the whole time, but only after sign-in, on a pill nobody had a reason to click twice.

| Surface | Before | After |
|---|---|---|
| Editor badge, signed out | "Watermarked" → sign-in, "signing in removes it" | "Watermark — remove for $19/mo" → sign-in named as the first step of checkout |
| Editor badge, signed in free | "Watermark — remove for $19/mo" | unchanged, now sharing one price constant |
| `/signin` | "Removes the watermark from video-editor exports" | "Saves your projects… removing the watermark is Starter, $19/mo" |
| Header sign-in dialog | same false line | same fix |

The popover keeps the honest parts — the mark pays for our Chromium, and a local `npx remotion render` is never marked.

Fixed all three copy sites together: one of them is the page the badge sends people to, and a funnel that corrects itself on step one and lies again on step two is the same bug twice.

**Still blocked on config:** the button reaches `/api/checkout`, which 503s until `DODO_API_KEY` / `DODO_WEBHOOK_SECRET` / `DODO_PRODUCT_STARTER` exist on the Coolify app. Only test-mode ids exist today.

Verified: `tsc` clean, `next build` clean, 78 files / 1330 tests, and the signed-out pill server-renders the price.