### PR TITLE
feat: markdown docs + component index for agents, and /v/<id> share links

### DIFF
--- a/app/(home)/v/[id]/page.tsx
+++ b/app/(home)/v/[id]/page.tsx
@@ -1,0 +1,193 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { GALLERY_ITEMS } from "@/lib/gallery-data";
+import { getSharedVideo } from "@/lib/server/shared-video";
+import { showcaseVideoUrl } from "@/lib/showcase/platform";
+import { SITE_URL } from "@/lib/structured-data";
+import { CANVAS } from "@/lib/video-editor/types";
+
+/**
+ * `/v/<id>` — a video somebody exported, at a permanent URL.
+ *
+ * ## What this page is for
+ *
+ * It is the only page on the site whose traffic does not depend on us. An
+ * export used to be an MP4 attached to a Slack message, and that view happened
+ * on Slack's servers; a link means every person who watches it arrives here
+ * instead. 87% of this site's traffic is already pasted links (`t.co` plus
+ * direct) — the difference is that those are our posts, and these are everyone
+ * else's, permanently, at no marginal cost.
+ *
+ * So the page is built for the *viewer*, who has never heard of snapcn: the
+ * video first at full width, then exactly one thing to do. It sits inside the
+ * `(home)` group so it inherits the site header and footer — that header is the
+ * conversion surface, and re-deciding what a share page's chrome should be
+ * would be a second answer to a question already answered.
+ *
+ * ## Why it is `noindex`
+ *
+ * Hundreds of pages holding a video, a title and no prose is thin content, and
+ * a domain that publishes it at volume gets treated accordingly — which would
+ * put the component docs at risk to chase traffic this page does not get from
+ * search anyway. It is `follow` rather than `noindex, nofollow` so the links
+ * out of it still count.
+ */
+export const dynamic = "force-dynamic";
+
+/** Slug → the gallery entry, so "built with" can link to real docs pages. */
+function galleryItemBySlug(slug: string) {
+  return GALLERY_ITEMS.find((item) => item.href.endsWith(`/${slug}`));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const video = await getSharedVideo(id);
+  if (!video) return { title: "Video not found", robots: { index: false } };
+
+  const title = video.title;
+  const description = video.authorName
+    ? `A video ${video.authorName} made with snapcn — Remotion components for product demo videos.`
+    : "Made with snapcn — Remotion components for product demo videos.";
+  const videoUrl = `${SITE_URL}${showcaseVideoUrl(video.jobId)}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/v/${id}` },
+    // Crawlable, deliberately not indexable — see the note on the component.
+    robots: { index: false, follow: true },
+    openGraph: {
+      // `video.other` rather than `website`: it is what makes X and Slack
+      // inline a player instead of a link preview, which is the difference
+      // between a shared link being watched and being scrolled past.
+      type: "video.other",
+      url: `/v/${id}`,
+      title,
+      description,
+      siteName: "snapcn",
+      images: [{ url: "/og", width: 1200, height: 630, alt: title }],
+      videos: [
+        {
+          url: videoUrl,
+          type: "video/mp4",
+          width: CANVAS.width,
+          height: CANVAS.height,
+        },
+      ],
+    },
+    twitter: {
+      card: "player",
+      title,
+      description,
+      images: ["/og"],
+      players: [
+        {
+          playerUrl: videoUrl,
+          streamUrl: videoUrl,
+          width: CANVAS.width,
+          height: CANVAS.height,
+        },
+      ],
+    },
+  };
+}
+
+export default async function SharedVideoPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const video = await getSharedVideo(id);
+  if (!video) notFound();
+
+  const used = (video.componentsUsed ?? [])
+    .map((slug) => ({ slug, item: galleryItemBySlug(slug) }))
+    .filter((entry) => entry.item);
+
+  return (
+    <div className="section py-10 sm:py-14">
+      <div className="mx-auto max-w-3xl">
+        {/* The video is the page. It leads, at the aspect it was rendered at,
+            with nothing above it to scroll past. `controls` only — autoplay on
+            a page someone arrived at from a link is how you get muted playback
+            they never notice started. */}
+        <div
+          className="overflow-hidden rounded-xl border border-border bg-black"
+          style={{ aspectRatio: `${CANVAS.width} / ${CANVAS.height}` }}
+        >
+          {/* biome-ignore lint/a11y/useMediaCaption: user-generated video with no caption track to offer */}
+          <video
+            className="h-full w-full"
+            src={showcaseVideoUrl(video.jobId)}
+            controls
+            playsInline
+            preload="metadata"
+          />
+        </div>
+
+        <h1 className="mt-6 text-pretty font-sans text-2xl font-normal tracking-[-0.02em] text-foreground sm:text-3xl">
+          {video.title}
+        </h1>
+
+        <p className="mt-2 text-sm text-current/60">
+          {video.authorName
+            ? `Made by ${video.authorName} with `
+            : "Made with "}
+          <Link href="/" className="underline underline-offset-2">
+            snapcn
+          </Link>
+          {" · "}
+          <time dateTime={video.createdAt.toISOString()}>
+            {video.createdAt.toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </time>
+        </p>
+
+        {/* The components are the product, named. A viewer who wants the thing
+            they just watched gets sent to the one that made it, not to a
+            gallery of thirty-two to search through. */}
+        {used.length > 0 && (
+          <p className="mt-4 flex flex-wrap items-center gap-2 text-sm text-current/60">
+            <span>Built with</span>
+            {used.map(({ slug, item }) => (
+              <Link
+                key={slug}
+                href={item?.href ?? "/docs/components"}
+                className="rounded-md border border-border px-2 py-0.5 font-mono text-xs text-foreground transition-colors hover:bg-muted"
+              >
+                {item?.name ?? slug}
+              </Link>
+            ))}
+          </p>
+        )}
+
+        {/* One action. The viewer's question after watching is "how", and the
+            editor answers it without an install, a signup or a Remotion
+            project — which is why it is the ask rather than the registry. */}
+        <div className="mt-8 flex flex-col items-start gap-3 border-t border-border pt-8 sm:flex-row sm:items-center">
+          <Button
+            size="lg"
+            className="h-11 px-6 text-sm"
+            nativeButton={false}
+            render={<Link href="/docs/video-editor" />}
+          >
+            Make one like this
+          </Button>
+          <p className="text-sm text-current/60">
+            Free, in your browser. No install, no Remotion project.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { isDbConfigured } from "@/lib/server/db";
+import { claimRender } from "@/lib/server/hosted-video";
+import { checkRateLimit } from "@/lib/server/rate-limit";
+import { getJob } from "@/lib/server/render-queue";
+import {
+  createSharedVideo,
+  normalizeShareInput,
+} from "@/lib/server/shared-video";
+
+/**
+ * POST /api/share — turn a finished render into a permanent page at `/v/<id>`.
+ *
+ * This is where the sign-in wall lives now, and deliberately not one step
+ * earlier. Export runs signed-out and the file reaches the user's disk either
+ * way; an account is what is needed to *keep the link*, because a permanent URL
+ * needs an owner who can delete it and because that account is the only thing
+ * that carries the upgrade later. Gating the export instead lost two of every
+ * three people at the moment they had nothing yet — 3 sign-ins opened, 1
+ * completed, measured over the editor's first month.
+ *
+ * The file is claimed before the row is written, same ordering as the showcase
+ * route and for the same reason: the export pipeline deletes the MP4 on
+ * download and sweeps it after ten minutes, so a row written first can end up
+ * naming a file that is already gone.
+ */
+export async function POST(req: Request) {
+  if (!isDbConfigured) {
+    return NextResponse.json(
+      { error: "Share links aren't configured yet." },
+      { status: 503 },
+    );
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: "Sign in to keep a link to this video." },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body." },
+      { status: 400 },
+    );
+  }
+
+  const { jobId, title, componentsUsed } = (body ?? {}) as {
+    jobId?: unknown;
+    title?: unknown;
+    componentsUsed?: unknown;
+  };
+
+  if (typeof jobId !== "string" || !jobId) {
+    return NextResponse.json({ error: "Missing render." }, { status: 400 });
+  }
+
+  // Keyed on the user rather than the IP: the route is authenticated, and each
+  // call keeps a multi-megabyte file forever. The budget is the disk, not abuse.
+  if (!checkRateLimit(session.user.id, "showcase")) {
+    return NextResponse.json(
+      { error: "Too many links. Please wait and retry." },
+      { status: 429 },
+    );
+  }
+
+  const job = getJob(jobId);
+  if (job?.status !== "done") {
+    return NextResponse.json(
+      { error: "That render isn't finished. Export it again and retry." },
+      { status: 409 },
+    );
+  }
+
+  if (!(await claimRender(jobId))) {
+    return NextResponse.json(
+      { error: "That video has expired. Export it again and retry." },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const { id } = await createSharedVideo({
+      userId: session.user.id,
+      jobId,
+      ...normalizeShareInput({ title, componentsUsed }),
+    });
+
+    return NextResponse.json({ id, url: `/v/${id}` }, { status: 201 });
+  } catch (err) {
+    console.error("[share] create failed:", err);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/showcase/route.ts
+++ b/app/api/showcase/route.ts
@@ -2,13 +2,10 @@ import { after, NextResponse } from "next/server";
 import { adminEmails, auth } from "@/auth";
 import { isDbConfigured } from "@/lib/server/db";
 import { sendEmail, showcaseReviewEmail } from "@/lib/server/email";
+import { claimRender } from "@/lib/server/hosted-video";
 import { checkRateLimit } from "@/lib/server/rate-limit";
 import { getJob } from "@/lib/server/render-queue";
-import {
-  claimRenderForShowcase,
-  createSubmission,
-  showcaseVideoUrl,
-} from "@/lib/server/showcase";
+import { createSubmission, showcaseVideoUrl } from "@/lib/server/showcase";
 import { submissionInputSchema } from "@/lib/showcase/validation";
 
 /** Create a showcase submission (auth required; lands as `pending`). */
@@ -71,7 +68,7 @@ export async function POST(req: Request) {
         { status: 409 },
       );
     }
-    if (!(await claimRenderForShowcase(jobId))) {
+    if (!(await claimRender(jobId))) {
       return NextResponse.json(
         { error: "That video has expired. Export it again and retry." },
         { status: 409 },

--- a/app/docs-md/[[...slug]]/route.ts
+++ b/app/docs-md/[[...slug]]/route.ts
@@ -1,0 +1,52 @@
+import { collectDocsPages, pageMarkdown, SITE_URL } from "@/lib/llms";
+
+export const dynamic = "force-static";
+
+/**
+ * Any docs URL with `.md` appended, as plain markdown.
+ *
+ * `next.config.ts` rewrites `/docs/:path*.md` here; nothing links to
+ * `/docs-md/*` and it is not in the sitemap, so the public URL stays the docs
+ * URL an agent already has.
+ *
+ * ## Why
+ *
+ * Appending `.md` is the convention coding agents try first, and until now
+ * snapcn answered it with a 200 and forty-seven kilobytes of React shell —
+ * the same failure mode `unknownComponent` in middleware.ts was written to fix,
+ * one layer up. An agent that spends its context on `<script>` tags does not
+ * get to the install command at the bottom of the page.
+ *
+ * The bytes are `pageMarkdown`, the same function `/llms-full.txt` emits, so a
+ * page fetched on its own and the same page inside the corpus can never
+ * disagree.
+ */
+export function generateStaticParams() {
+  return collectDocsPages()
+    .filter((page) => page.url !== "/docs")
+    .map((page) => ({ slug: page.url.replace("/docs/", "").split("/") }));
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug } = await params;
+  const url = slug?.length ? `/docs/${slug.join("/")}` : "/docs";
+  const page = collectDocsPages().find((entry) => entry.url === url);
+
+  // Answer a miss in the language it was asked in, as the registry 404 does.
+  if (!page) {
+    return new Response(
+      `# Not found\n\nThere is no snapcn docs page at \`${url}\`.\nEvery page: ${SITE_URL}/llms.txt\nEvery component: ${SITE_URL}/llms-components.txt\n`,
+      {
+        status: 404,
+        headers: { "Content-Type": "text/markdown; charset=utf-8" },
+      },
+    );
+  }
+
+  return new Response(`${pageMarkdown(page)}\n`, {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/app/llms-components.txt/route.ts
+++ b/app/llms-components.txt/route.ts
@@ -1,0 +1,17 @@
+import { componentIndex } from "@/lib/llms";
+
+export const dynamic = "force-static";
+
+/**
+ * llms-components.txt: every installable component in one table — name, what it
+ * is for, how long it runs, what it pulls in, and where its full page is.
+ *
+ * `llms.txt` indexes pages and `/llms-full.txt` is the whole corpus; this sits
+ * between them and is the one an agent building a video actually wants, because
+ * choosing a component is the only decision it has to make before installing.
+ */
+export function GET() {
+  return new Response(componentIndex(), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,4 +1,4 @@
-import { collectDocsPages, LLMS_HEADER, SITE_URL } from "@/lib/llms";
+import { collectDocsPages, LLMS_HEADER, pageMarkdown } from "@/lib/llms";
 
 export const dynamic = "force-static";
 
@@ -10,19 +10,7 @@ export const dynamic = "force-static";
 export function GET() {
   const pages = collectDocsPages();
 
-  const body = pages
-    .map((page) =>
-      [
-        `# ${page.title}`,
-        `URL: ${SITE_URL}${page.url}`,
-        page.description,
-        "",
-        page.body,
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    )
-    .join("\n\n---\n\n");
+  const body = pages.map(pageMarkdown).join("\n\n---\n\n");
 
   return new Response(`${LLMS_HEADER}\n${body}\n`, {
     headers: { "Content-Type": "text/plain; charset=utf-8" },

--- a/components/video-editor/share-link.tsx
+++ b/components/video-editor/share-link.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { Check, Copy, Link2 } from "lucide-react";
+import Link from "next/link";
+import { type FormEvent, useState } from "react";
+import { toast } from "sonner";
+import { SignInButtons } from "@/components/showcase/sign-in-buttons";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { AuthProviderId } from "@/lib/auth-providers";
+import type { AudioTrack, Clip } from "@/lib/video-editor/types";
+
+/**
+ * Turn the timeline into a page at `/v/<id>` that anyone can open.
+ *
+ * ## Why this is a separate button and not part of Export
+ *
+ * The download route deletes the MP4 as it streams — an export is scratch by
+ * design. Keeping the file has to happen *instead of* downloading it, which is
+ * what `onDone` is for, and that makes it a second action rather than a
+ * follow-up offer on the first. Nothing is lost by it: the video is playable and
+ * downloadable from the share page afterwards, so one render still gets you both
+ * a link and a file.
+ *
+ * ## The sign-in
+ *
+ * This is the only place in the export flow that requires an account, and it is
+ * the right place: the file needs no owner, a permanent URL does — somebody has
+ * to be able to delete it, and that account is what carries the upgrade later.
+ * Gating the export itself lost two of every three people before they had
+ * anything (3 sign-ins opened, 1 completed, over the editor's first month).
+ */
+export function ShareLink({
+  clips,
+  font,
+  audio,
+  signedIn,
+  providers,
+  emailEnabled,
+  exporting,
+  progress,
+  download,
+}: {
+  clips: Clip[];
+  font: string;
+  audio: AudioTrack | null;
+  signedIn: boolean;
+  providers: AuthProviderId[];
+  emailEnabled: boolean;
+  exporting: boolean;
+  progress: number;
+  /** The editor's one `useEditorExport` instance, shared rather than a second. */
+  download: (
+    clips: Clip[],
+    opts: {
+      removeWatermark?: boolean;
+      font?: string;
+      audio?: {
+        uploadId: string | null;
+        volume: number;
+        trimStart: number;
+      } | null;
+      onDone?: (jobId: string) => Promise<void> | void;
+    },
+  ) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [url, setUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    await download(clips, {
+      // A shared page is an advert, so it carries the mark whatever the plan —
+      // the same rule the showcase submission follows.
+      removeWatermark: false,
+      font,
+      audio: audio
+        ? {
+            uploadId: audio.uploadId,
+            volume: audio.volume,
+            trimStart: audio.trimStart,
+          }
+        : null,
+      onDone: async (jobId) => {
+        try {
+          const res = await fetch("/api/share", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jobId,
+              title,
+              // Slugs, so the page can name and link what built the video.
+              componentsUsed: [...new Set(clips.map((clip) => clip.slug))],
+            }),
+          });
+          const data = (await res.json().catch(() => ({}))) as {
+            url?: string;
+            error?: string;
+          };
+          if (!res.ok || !data.url) {
+            toast.error(data.error ?? "Couldn't create a link — try again.");
+            return;
+          }
+          setUrl(`${window.location.origin}${data.url}`);
+        } catch {
+          toast.error("Network error — please try again.");
+        }
+      },
+    });
+  }
+
+  async function copy() {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard is blocked (insecure context, denied permission). The input
+      // below is readable and selectable, so there is still a way to get it.
+      toast.error("Couldn't copy — select the link and copy it.");
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        // A closed dialog reopening onto the previous link would offer a stale
+        // URL for a timeline that has since changed.
+        if (!next) {
+          setUrl(null);
+          setTitle("");
+        }
+      }}
+    >
+      <DialogTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            disabled={clips.length === 0}
+          />
+        }
+      >
+        <Link2 className="size-4" />
+        <span className="hidden sm:inline">Get a link</span>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {url ? "Your link is ready" : "Get a shareable link"}
+          </DialogTitle>
+          <DialogDescription>
+            {url
+              ? "Anyone with this link can watch it. Paste it instead of attaching the file."
+              : signedIn
+                ? "We'll render your video and host it at a permanent URL you can send to anyone."
+                : "Sign in to keep the link — a hosted video is attached to your account."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {url ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-2">
+              <Input readOnly value={url} className="font-mono text-xs" />
+              <Button
+                variant="outline"
+                onClick={copy}
+                aria-label="Copy link"
+                className="shrink-0"
+              >
+                {copied ? (
+                  <Check className="size-4" />
+                ) : (
+                  <Copy className="size-4" />
+                )}
+              </Button>
+            </div>
+            <Button
+              variant="outline"
+              nativeButton={false}
+              // `Link`, not a bare `<a>`: the anchor-content lint cannot see
+              // that `Button` injects the label through `render`, and every
+              // other link in this codebase goes through `Link` anyway.
+              render={<Link href={url} target="_blank" rel="noreferrer" />}
+            >
+              Open the page
+            </Button>
+          </div>
+        ) : signedIn ? (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="share-title">Title</Label>
+              <Input
+                id="share-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Product launch teaser"
+                required
+                maxLength={120}
+              />
+            </div>
+            <Button type="submit" disabled={exporting} className="w-full">
+              {exporting
+                ? `Rendering… ${Math.round(progress * 100)}%`
+                : "Create link"}
+            </Button>
+          </form>
+        ) : (
+          <SignInButtons
+            providers={providers}
+            emailEnabled={emailEnabled}
+            callbackUrl="/docs/video-editor"
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/video-editor/video-editor.tsx
+++ b/components/video-editor/video-editor.tsx
@@ -56,6 +56,7 @@ import {
 import { LibraryPanel } from "./library-panel";
 import { ProjectMenu } from "./project-menu";
 import { PropertiesPanel } from "./properties-panel";
+import { ShareLink } from "./share-link";
 import { SubmitToShowcase } from "./submit-to-showcase";
 import { TimelineStrip } from "./timeline-strip";
 import { useEditorExport } from "./use-editor-export";
@@ -449,6 +450,19 @@ export function VideoEditor({
             emailEnabled={emailEnabled}
             removeWatermark={removeWatermark}
             onRemoveWatermarkChange={setRemoveWatermark}
+          />
+          {/* Before Submit: a link is the thing most people want, and the
+              showcase is the small subset who want it reviewed and listed. */}
+          <ShareLink
+            clips={clips}
+            font={font}
+            audio={audio}
+            signedIn={signedIn}
+            providers={providers}
+            emailEnabled={emailEnabled}
+            exporting={exporting}
+            progress={progress}
+            download={download}
           />
           <SubmitToShowcase
             clips={clips}

--- a/drizzle/0005_modern_tomas.sql
+++ b/drizzle/0005_modern_tomas.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "shared_video" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"job_id" text NOT NULL,
+	"title" text DEFAULT 'Untitled video' NOT NULL,
+	"components_used" text[],
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "shared_video_job_id_unique" UNIQUE("job_id")
+);
+--> statement-breakpoint
+ALTER TABLE "shared_video" ADD CONSTRAINT "shared_video_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "shared_video_user_created_idx" ON "shared_video" USING btree ("user_id","created_at");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,768 @@
+{
+  "id": "954b3fe5-d73b-437e-baff-dea08ef6e9ca",
+  "prevId": "083ca190-0096-4ca8-baad-393ef45245ae",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_subscription": {
+      "name": "billing_subscription",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "dodo_subscription_id": {
+          "name": "dodo_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dodo_customer_id": {
+          "name": "dodo_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_subscription_user_id_user_id_fk": {
+          "name": "billing_subscription_user_id_user_id_fk",
+          "tableFrom": "billing_subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_subscription_api_key_unique": {
+          "name": "billing_subscription_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_usage": {
+      "name": "render_usage",
+      "schema": "",
+      "columns": {
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renders_used": {
+          "name": "renders_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "render_usage_pk": {
+          "name": "render_usage_pk",
+          "columns": [
+            "meter_key",
+            "period_month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_video": {
+      "name": "shared_video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled video'"
+        },
+        "components_used": {
+          "name": "components_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_video_user_created_idx": {
+          "name": "shared_video_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_video_user_id_user_id_fk": {
+          "name": "shared_video_user_id_user_id_fk",
+          "tableFrom": "shared_video",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shared_video_job_id_unique": {
+          "name": "shared_video_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.showcase_submission": {
+      "name": "showcase_submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_url": {
+          "name": "post_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "showcase_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "components_used": {
+          "name": "components_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "showcase_submission_user_id_user_id_fk": {
+          "name": "showcase_submission_user_id_user_id_fk",
+          "tableFrom": "showcase_submission",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriber": {
+      "name": "subscriber",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'home'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriber_email_unique": {
+          "name": "subscriber_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video_project": {
+      "name": "video_project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled video'"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "video_project_user_idx": {
+          "name": "video_project_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "video_project_user_id_user_id_fk": {
+          "name": "video_project_user_id_user_id_fk",
+          "tableFrom": "video_project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "starter",
+        "pro"
+      ]
+    },
+    "public.showcase_platform": {
+      "name": "showcase_platform",
+      "schema": "public",
+      "values": [
+        "x",
+        "facebook",
+        "linkedin",
+        "youtube",
+        "instagram",
+        "tiktok",
+        "other"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787915360769,
       "tag": "0004_colossal_george_stacy",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788444956563,
+      "tag": "0005_modern_tomas",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -269,3 +269,51 @@ export const renderUsage = pgTable(
     }),
   ],
 );
+
+/**
+ * A finished export, kept, with a public page at `/v/<id>`.
+ *
+ * ## Why this is not a `showcase_submission`
+ *
+ * The two look identical — a claimed MP4 plus a row — and they are not the same
+ * thing. A submission is authored, moderated, and listed in a public gallery. A
+ * shared video is created automatically the moment someone asks for a link, is
+ * never listed anywhere, and is only reachable by knowing its id.
+ *
+ * Overloading `showcase_submission` with an extra status would work today and
+ * leak later: every showcase query would have to remember to exclude the new
+ * state, and one that forgot would publish a stranger's private video into the
+ * gallery. `app/r/[file]/route.ts` already states the rule this follows — "a
+ * gate that has to remember to say no is one refactor away from saying yes".
+ *
+ * `jobId` is both the storage key and the render it came from: the file lives at
+ * `SHOWCASE_WORK_DIR/<jobId>.mp4` and is streamed by the same range-capable
+ * route the showcase uses, so hosting a share link added no new storage path
+ * and no second player.
+ */
+export const sharedVideos = pgTable(
+  "shared_video",
+  {
+    /** What appears in the URL. Unguessable, and not the render's id. */
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    /**
+     * Basename of the claimed MP4, which is the render job's own uuid.
+     *
+     * Unique: claiming moves the file, so a second row for the same job would
+     * be a second page pointing at one file — and deleting either would break
+     * the other.
+     */
+    jobId: text("job_id").notNull().unique(),
+    title: text("title").notNull().default("Untitled video"),
+    /** For "built with", and so a page can link the components it used. */
+    componentsUsed: text("components_used").array(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  // "My links", newest first, is the only list this table is ever queried for.
+  (t) => [index("shared_video_user_created_idx").on(t.userId, t.createdAt)],
+);

--- a/lib/llms.ts
+++ b/lib/llms.ts
@@ -281,4 +281,127 @@ Prerequisites: an existing Remotion project (\`npx create-video@latest\`) and th
 Maintained by Sri Nath. Project account: https://x.com/snapcndev
 Last updated: ${lastUpdated()} (newest component release)
 
+Building a video? Start at ${SITE_URL}/llms-components.txt — every installable
+component in one table with what it is for, how many frames it runs and what it
+pulls in, linking to each component's full page. Any docs URL also serves raw
+markdown: append \`.md\`.
+
 ${INSTALLABLE}`;
+
+/**
+ * One page as the plain-markdown block that `/llms-full.txt` and the `.md` URLs
+ * both emit — the same bytes either way, so an agent that fetches a single page
+ * and one that ingests the whole corpus never see two different documents.
+ */
+export function pageMarkdown(page: LlmsPage): string {
+  return [
+    `# ${page.title}`,
+    `URL: ${SITE_URL}${page.url}`,
+    page.description,
+    "",
+    page.body,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** What the render pipeline measured for each component, keyed by name. */
+interface Measured {
+  fps: number;
+  durationInFrames: number;
+}
+
+function measurements(): Record<string, Measured> {
+  try {
+    const raw = fs.readFileSync(
+      path.join(process.cwd(), "registry", "__measured__.json"),
+      "utf8",
+    );
+    return JSON.parse(raw).components ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * What `shadcn add` pulls in alongside one component, read off the built
+ * registry item rather than restated here — npm packages first, then the
+ * snapcn primitives the CLI installs transitively.
+ */
+function dependencies(name: string): string[] {
+  try {
+    const raw = fs.readFileSync(
+      path.join(process.cwd(), "public", "r", `${name}.json`),
+      "utf8",
+    );
+    const item = JSON.parse(raw) as {
+      dependencies?: string[];
+      registryDependencies?: string[];
+    };
+    const registry = (item.registryDependencies ?? []).map((dep) => {
+      const bare =
+        dep
+          .split("/")
+          .pop()
+          ?.replace(/\.json$/, "") ?? dep;
+      return dep.startsWith("http") ? `@snapcn/${bare}` : bare;
+    });
+    return [...(item.dependencies ?? []), ...registry];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * `/llms-components.txt` — every installable component in one table.
+ *
+ * `llms.txt` names the *pages*; this names the *components*, with the two facts
+ * that decide which one to reach for — what it is for and how long it runs — so
+ * an agent picks from a single fetch instead of opening thirty docs pages to
+ * find out. It is the router; the `.md` pages are the reference.
+ *
+ * Built by intersecting the gallery with `INSTALL_ALL_NAMES`, deliberately.
+ * That list is the free registry and nothing else, so a component that has not
+ * been published cannot reach this file by being added to the gallery early.
+ */
+export function componentIndex(): string {
+  const measured = measurements();
+  const installable = new Set(INSTALL_ALL_NAMES);
+
+  const tables = GALLERY_CATEGORIES.map((cat) => {
+    const rows = GALLERY_ITEMS.filter((item) => item.category === cat.id)
+      .map((item) => ({ item, name: item.href.split("/").pop() ?? "" }))
+      .filter(({ name }) => installable.has(name))
+      .map(({ item, name }) => {
+        const m = measured[name];
+        const length = m ? `${m.durationInFrames}f @ ${m.fps}fps` : "—";
+        const deps = dependencies(name);
+        return `| \`${name}\` | ${item.description} | ${length} | ${
+          deps.length ? deps.map((d) => `\`${d}\``).join(", ") : "—"
+        } | [docs](${SITE_URL}${item.href}.md) |`;
+      });
+
+    return rows.length
+      ? `## ${cat.label}\n\n| Component | Use for | Length | Deps | Docs |\n|---|---|---|---|---|\n${rows.join("\n")}`
+      : "";
+  }).filter(Boolean);
+
+  return `# snapcn component index
+
+> Every installable snapcn component in one file. Scan the tables, pick by
+> \`Use for\`, then fetch only the component pages you need.
+
+Install any entry: \`npx shadcn@latest add @snapcn/<name>\`. The source is copied
+into the project and the caller owns it — MIT, with no runtime dependency on
+snapcn. \`Deps\` installs transitively; do not add those by hand.
+
+\`Length\` is how many frames the component's own animation runs at its native
+fps. It is the floor for the \`<Sequence>\` that wraps it, not the whole beat:
+add hold time on top when the element should stay on screen after it settles.
+
+Full reference for one component — props, examples, the interactive preview —
+lives at its Docs link. Every docs URL serves raw markdown: append \`.md\`.
+
+${tables.join("\n\n")}
+`;
+}

--- a/lib/server/__tests__/shared-video.test.ts
+++ b/lib/server/__tests__/shared-video.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for `normalizeShareInput` in lib/server/shared-video.ts
+ *
+ * Run with:  pnpm vitest run lib/server/__tests__/shared-video.test.ts
+ *
+ * The rest of the module is Drizzle queries; this is the only part with
+ * branching, and it sits on a trust boundary — every value here arrives in a
+ * `fetch` body from the browser and ends up on a public page.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { MAX_TITLE, normalizeShareInput } from "@/lib/server/shared-video";
+
+describe("normalizeShareInput", () => {
+  it("falls back to a title rather than storing an empty one", () => {
+    for (const title of [undefined, null, "", "   ", 42, {}]) {
+      expect(normalizeShareInput({ title }).title).toBe("Untitled video");
+    }
+  });
+
+  it("trims and caps the title", () => {
+    expect(normalizeShareInput({ title: "  Launch teaser  " }).title).toBe(
+      "Launch teaser",
+    );
+    const long = "a".repeat(MAX_TITLE + 50);
+    expect(normalizeShareInput({ title: long }).title).toHaveLength(MAX_TITLE);
+  });
+
+  it("keeps registry slugs and drops everything else", () => {
+    // The teeth of this function: these values are rendered as text and as
+    // `href`s on /v/<id>, so a path, a protocol or a tag must not survive.
+    const { componentsUsed } = normalizeShareInput({
+      componentsUsed: [
+        "text-reveal",
+        "phone-frame",
+        "../../etc/passwd",
+        "javascript:alert(1)",
+        "<script>",
+        "Text Reveal",
+        "text_reveal",
+        "",
+        null,
+        7,
+      ],
+    });
+    expect(componentsUsed).toEqual(["text-reveal", "phone-frame"]);
+  });
+
+  it("distinguishes 'no list sent' from 'nothing in the list survived'", () => {
+    // `undefined` writes SQL NULL; `[]` writes an empty array. The page reads
+    // both as "no components", but conflating them here would mean a caller
+    // that sent junk looked identical to one that sent nothing.
+    expect(normalizeShareInput({}).componentsUsed).toBeUndefined();
+    expect(normalizeShareInput({ componentsUsed: "nope" }).componentsUsed).toBe(
+      undefined,
+    );
+    expect(normalizeShareInput({ componentsUsed: ["Nope!"] })).toMatchObject({
+      componentsUsed: [],
+    });
+  });
+});

--- a/lib/server/hosted-video.ts
+++ b/lib/server/hosted-video.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import path from "node:path";
+import { RENDER_WORK_DIR, SHOWCASE_WORK_DIR } from "@/lib/server/paths";
+
+/**
+ * Keeping a finished render instead of letting the export pipeline delete it.
+ *
+ * Two features need this and they need exactly the same thing: a showcase
+ * submission and a `/v/<id>` share link. It lives here rather than in either
+ * one so neither imports the other, and so there is one copy of the rename —
+ * the part with the filesystem edge case in it.
+ */
+
+/**
+ * Take a finished render out of the scratch dir and keep it.
+ *
+ * The export pipeline deletes an MP4 the moment its download stream ends and
+ * sweeps anything left after ten minutes — correct for an export, fatal for
+ * anything with a permanent URL. Moving the file is what turns one into the
+ * other, and a rename is the whole operation: same filesystem, atomic, no copy
+ * of a multi-megabyte file, and no window where the sweep can take it
+ * mid-flight.
+ *
+ * Returns false when there is nothing to claim — a jobId from a previous
+ * process, one already swept, or one that was never real. The caller must treat
+ * that as a failure rather than storing a row pointing at nothing.
+ */
+export async function claimRender(jobId: string): Promise<boolean> {
+  const from = path.join(RENDER_WORK_DIR, `${jobId}.mp4`);
+  const to = path.join(SHOWCASE_WORK_DIR, `${jobId}.mp4`);
+
+  try {
+    if (!(await stat(from)).isFile()) return false;
+  } catch {
+    return false;
+  }
+
+  await mkdir(SHOWCASE_WORK_DIR, { recursive: true });
+  try {
+    await rename(from, to);
+  } catch (err) {
+    // ponytail: EXDEV only — the two dirs are on different filesystems, which
+    // happens the moment SHOWCASE_WORK_DIR is a mounted volume and the renders
+    // stay on tmpfs. Copy then unlink. Put both dirs on the same volume and
+    // this branch never runs.
+    if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+    await copyFile(from, to);
+    await rm(from, { force: true });
+  }
+  return true;
+}

--- a/lib/server/shared-video.ts
+++ b/lib/server/shared-video.ts
@@ -1,0 +1,134 @@
+import "server-only";
+import { desc, eq } from "drizzle-orm";
+import { sharedVideos, users } from "@/lib/db/schema";
+import { getDb, isDbConfigured } from "@/lib/server/db";
+
+/**
+ * Share links: a finished export kept at a permanent URL.
+ *
+ * The point of the feature, in one line: today an export is an MP4 someone
+ * attaches somewhere, and that view happens on Slack's servers. A link means
+ * every person who watches it lands here instead, on a page that says what made
+ * it. Every export becomes a piece of distribution that costs nothing to run.
+ *
+ * There is no listing query and no "all shares" read. A share is reachable by
+ * its id or by its owner, and that is the whole access model — see the note on
+ * {@link sharedVideos} for why this is not a showcase submission.
+ */
+
+/** Longest title we will store. Past this it is not a title, it is a body. */
+export const MAX_TITLE = 120;
+
+/**
+ * What a client sent, reduced to what we are willing to store.
+ *
+ * Exported for test (same convention as `buildSpec` in app/api/render): this is
+ * a trust boundary — the values arrive from a `fetch` body — and the two rules
+ * that matter are easier to prove here than through a mocked route. The slug
+ * filter is the one with teeth: `componentsUsed` ends up rendered as text and as
+ * `href`s on a public page, so anything that is not a registry slug shape is
+ * dropped rather than escaped.
+ */
+export function normalizeShareInput(input: {
+  title?: unknown;
+  componentsUsed?: unknown;
+}): { title: string; componentsUsed: string[] | undefined } {
+  const title =
+    typeof input.title === "string" && input.title.trim()
+      ? input.title.trim().slice(0, MAX_TITLE)
+      : "Untitled video";
+
+  const componentsUsed = Array.isArray(input.componentsUsed)
+    ? input.componentsUsed.filter(
+        (slug): slug is string =>
+          typeof slug === "string" && /^[a-z0-9-]+$/.test(slug),
+      )
+    : undefined;
+
+  return { title, componentsUsed };
+}
+
+export type SharedVideo = {
+  id: string;
+  jobId: string;
+  title: string;
+  componentsUsed: string[] | null;
+  createdAt: Date;
+  authorName: string | null;
+  authorImage: string | null;
+};
+
+export async function createSharedVideo(input: {
+  userId: string;
+  jobId: string;
+  title: string;
+  componentsUsed?: string[];
+}): Promise<{ id: string }> {
+  const [row] = await getDb()
+    .insert(sharedVideos)
+    .values({
+      userId: input.userId,
+      jobId: input.jobId,
+      title: input.title,
+      componentsUsed: input.componentsUsed ?? null,
+    })
+    .returning({ id: sharedVideos.id });
+  return row;
+}
+
+/**
+ * One share, by the id in its URL. `null` for anything else.
+ *
+ * Joined to `users` so the page can credit whoever made it; a left join because
+ * the author row can be gone (account deleted cascades the share, but not in the
+ * window between the two) and a missing name is a byline we skip, not a 500.
+ */
+export async function getSharedVideo(id: string): Promise<SharedVideo | null> {
+  if (!isDbConfigured) return null;
+  try {
+    const [row] = await getDb()
+      .select({
+        id: sharedVideos.id,
+        jobId: sharedVideos.jobId,
+        title: sharedVideos.title,
+        componentsUsed: sharedVideos.componentsUsed,
+        createdAt: sharedVideos.createdAt,
+        authorName: users.name,
+        authorImage: users.image,
+      })
+      .from(sharedVideos)
+      .leftJoin(users, eq(sharedVideos.userId, users.id))
+      .where(eq(sharedVideos.id, id))
+      .limit(1);
+    return row ?? null;
+  } catch (err) {
+    console.error("[share] getSharedVideo failed:", err);
+    return null;
+  }
+}
+
+/** Somebody's own links, newest first. Backs "my links" in the account menu. */
+export async function getSharedVideosForUser(
+  userId: string,
+): Promise<SharedVideo[]> {
+  if (!isDbConfigured) return [];
+  try {
+    return await getDb()
+      .select({
+        id: sharedVideos.id,
+        jobId: sharedVideos.jobId,
+        title: sharedVideos.title,
+        componentsUsed: sharedVideos.componentsUsed,
+        createdAt: sharedVideos.createdAt,
+        authorName: users.name,
+        authorImage: users.image,
+      })
+      .from(sharedVideos)
+      .leftJoin(users, eq(sharedVideos.userId, users.id))
+      .where(eq(sharedVideos.userId, userId))
+      .orderBy(desc(sharedVideos.createdAt));
+  } catch (err) {
+    console.error("[share] getSharedVideosForUser failed:", err);
+    return [];
+  }
+}

--- a/lib/server/showcase.ts
+++ b/lib/server/showcase.ts
@@ -1,11 +1,8 @@
 import "server-only";
-import { copyFile, mkdir, rename, rm, stat } from "node:fs/promises";
-import path from "node:path";
 import { desc, eq } from "drizzle-orm";
 import { revalidateTag, unstable_cache } from "next/cache";
 import { showcaseSubmissions, users } from "@/lib/db/schema";
 import { getDb, isDbConfigured } from "@/lib/server/db";
-import { RENDER_WORK_DIR, SHOWCASE_WORK_DIR } from "@/lib/server/paths";
 import {
   detectPlatform,
   isHostedVideo,
@@ -13,49 +10,6 @@ import {
 } from "@/lib/showcase/platform";
 
 export { isHostedVideo, showcaseVideoUrl } from "@/lib/showcase/platform";
-
-/**
- * Take a finished render out of the scratch dir and keep it.
- *
- * The export pipeline deletes an MP4 the moment its download stream ends and
- * sweeps anything left after ten minutes — correct for an export, fatal for a
- * submission. Moving the file is what turns one into the other, and a rename is
- * the whole operation: same filesystem, atomic, no copy of a multi-megabyte
- * file, and no window where the sweep can take it mid-flight.
- *
- * Returns false when there is nothing to claim — a jobId from a previous
- * process, one already swept, or one that was never real. The caller must treat
- * that as a failed submission rather than storing a row pointing at nothing.
- */
-export async function claimRenderForShowcase(jobId: string): Promise<boolean> {
-  const from = path.join(RENDER_WORK_DIR, `${jobId}.mp4`);
-  const to = path.join(SHOWCASE_WORK_DIR, `${jobId}.mp4`);
-
-  try {
-    if (!(await stat(from)).isFile()) return false;
-  } catch {
-    return false;
-  }
-
-  await mkdir(SHOWCASE_WORK_DIR, { recursive: true });
-  try {
-    await rename(from, to);
-  } catch (err) {
-    // ponytail: EXDEV only — the two dirs are on different filesystems, which
-    // happens the moment SHOWCASE_WORK_DIR is a mounted volume and the renders
-    // stay on tmpfs. Copy then unlink. Put both dirs on the same volume and
-    // this branch never runs.
-    if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
-    await copyFile(from, to);
-    await rm(from, { force: true });
-  }
-  return true;
-}
-
-/** Drop a hosted video. Called when its submission is rejected. */
-export async function discardShowcaseVideo(jobId: string): Promise<void> {
-  await rm(path.join(SHOWCASE_WORK_DIR, `${jobId}.mp4`), { force: true });
-}
 
 export type ShowcaseItem = {
   id: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -100,7 +100,10 @@ export async function middleware(request: NextRequest) {
       $current_url: request.nextUrl.href,
     };
 
-    if (pathname === "/llms.txt" || pathname === "/llms-full.txt") {
+    // Every agent-facing surface reports as one event so the channel reads as a
+    // single number: the three plain-text indexes and the `.md` form of any
+    // docs page. `file` keeps them apart when the breakdown is wanted.
+    if (pathname.endsWith(".txt") || pathname.endsWith(".md")) {
       await captureServer("llms_txt_fetched", distinctId, {
         ...shared,
         file: pathname.slice(1),
@@ -169,6 +172,16 @@ function unknownComponent(component: string, origin: string): NextResponse {
   );
 }
 
+/**
+ * `/docs/:path*.md` is matched, plain `/docs/*` is not — so the HTML docs keep
+ * costing nothing and only the agent-shaped request pays for the capture.
+ */
 export const config = {
-  matcher: ["/r/:path*", "/llms.txt", "/llms-full.txt"],
+  matcher: [
+    "/r/:path*",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/llms-components.txt",
+    "/docs/:path*.md",
+  ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -67,6 +67,12 @@ const nextConfig: NextConfig = {
         destination: `${POSTHOG_ASSETS}/static/:path*`,
       },
       { source: "/ingest/:path*", destination: `${POSTHOG_INGEST}/:path*` },
+      // `<docs url>.md` serves that page as markdown. A rewrite rather than a
+      // route because `app/docs/[[...slug]]/page.tsx` already owns this path
+      // and a second handler on it will not build; the public URL is still the
+      // docs URL, which is the whole point — an agent appends `.md` to the link
+      // it already has and does not need to learn a second URL shape.
+      { source: "/docs/:path*.md", destination: "/docs-md/:path*" },
     ];
   },
   // Rendered demos always ship to the SAME path (`/demos/<slug>.mp4`), so a

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "render:previews": "node scripts/render-previews.mts",
     "motion:measure": "node scripts/motion-check.mts",
     "postinstall": "fumadocs-mdx",
-    "split:pro": "node scripts/split-pro.mts"
+    "split:pro": "node scripts/split-pro.mts",
+    "db:migrate": "node --env-file=.env.local ./node_modules/drizzle-kit/bin.cjs migrate"
   },
   "packageManager": "pnpm@10.33.0",
   "dependencies": {


### PR DESCRIPTION
Two changes that both aim at the same thing: making a snapcn video reachable without going through us.

## 1. Agent surface

`snapcn.dev/docs/text/text-reveal.md` returned **47,641 bytes of React shell** with a `200` and `content-type: text/html`. Appending `.md` is the first thing a coding agent tries, and it was being handed markup instead of content.

- `/docs/:path*.md` rewrites to a new route emitting `pageMarkdown` — the same function `/llms-full.txt` uses, so a page fetched alone and the same page inside the corpus cannot disagree. **47,641 → 2,435 bytes**, `text/markdown`.
- New `/llms-components.txt`: every installable component in one table (what it is for, frames at native fps, deps, link to its `.md`). `llms.txt` indexes *pages*; picking a *component* is the decision an agent actually has to make.
- Built from `INSTALL_ALL_NAMES` ∩ gallery, so an unpublished component cannot leak in by being added to the gallery early. Verified: zero pro names present.
- Middleware counts `.md` and the index as `llms_txt_fetched`. Plain `/docs/*` stays unmatched and costs nothing.

## 2. `/v/<id>` share links

An export is scratch — the download route deletes the MP4 as it streams, the sweep takes the rest after ten minutes. So a finished video's only view happens on Slack's servers.

- `claimRender` moves out of `showcase.ts` into `hosted-video.ts`; two features need the same atomic rename and neither should import the other.
- `shared_video` is its own table, not a status on `showcase_submission` — an extra status would mean every showcase query had to remember to exclude it, and the one that forgot would publish a private video into the public gallery.
- **The sign-in wall moves.** Export stays signed-out; an account is required to keep the *link*, not the file. Gating the export lost 2 of every 3 people before they had anything (3 opened, 1 completed).
- Page is `noindex, follow` and out of the sitemap — hundreds of pages with a video and no prose is thin content and would put the component docs at risk. Carries `og:video` + `twitter:player` so X and Slack inline a player.
- No new storage: reuses `SHOWCASE_WORK_DIR` and the existing range-capable `/api/showcase/video/[id]`.

## Also

`pnpm db:migrate` — `drizzle-kit` doesn't load `.env.local`, so the command in `SHOWCASE_SETUP.md` silently fell back to `localhost:5432` and applied nothing. That's why `0004` (`billing_subscription.api_key`) had never reached the database; `planForApiKey` was querying a column that didn't exist.

## Checks

`pnpm build` ✅ · `tsc --noEmit` ✅ · `biome check` ✅ · `vitest` 1348 passed (4 new, on the `/api/share` trust boundary) · endpoints verified against a local production build.

## Deploy notes

- Run `pnpm db:migrate` (applies `0004` + `0005`; both additive).
- `SHOWCASE_WORK_DIR` must point at a mounted volume — it currently warns and writes to `/tmp`, which loses every share link on redeploy.
- `ponytail:` comment marks the R2 swap when credentials exist; storage is behind one module.
